### PR TITLE
Fix navertv 修复韩国板块的navertv检测

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -2970,9 +2970,9 @@ function MediaUnlockTest_NaverTV() {
     local playable=$(echo "$tmpresult" | python -m json.tool 2>/dev/null | grep -o '"playable": *"[^"]*"' | cut -d'"' -f4)
 
     if [[ "$playable" == "NOT_COUNTRY_AVAILABLE" ]]; then
-        echo -n -e "\r Naver TV:\t\t\t\t${Font_Green}No${Font_Suffix}\n"
+        echo -n -e "\r Naver TV:\t\t\t\t${Font_Red}No${Font_Suffix}\n"
     else
-        echo -n -e "\r Naver TV:\t\t\t\t${Font_Red}Yes${Font_Suffix}\n"
+        echo -n -e "\r Naver TV:\t\t\t\t${Font_Green}Yes${Font_Suffix}\n"
     fi
     # local result=$(echo "$tmpresult" | python -m json.tool 2>/dev/null | grep ctry | cut -f4 -d'"')
     # if [[ "$result" == "KR" ]]; then

--- a/check.sh
+++ b/check.sh
@@ -2952,8 +2952,14 @@ function MediaUnlockTest_CoupangPlay() {
 }
 
 function MediaUnlockTest_NaverTV() {
-    local timestamp=$(date +%s%3N)
-    local tmpresult=$(curl $useNIC $usePROXY $xForward -${1} -s --max-time 10 "https://apis.naver.com/now_web2/now_web_api/v1/clips/31030608/meta-info?msgpad=${timestamp}&md=SCrXvFnuzUU4qaZbxG%2BVhc0gjCQ%3D" --user-agent "${UA_Browser}" -H 'host: apis.naver.com' -H 'connection: keep-alive' -H "sec-ch-ua: ${UA_SecCHUA}" -H 'accept: application/json, text/plain, */*' -H 'sec-ch-ua-mobile: ?0' -H 'sec-ch-ua-platform: "Windows"' -H 'origin: https://tv.naver.com' -H 'sec-fetch-site: same-site' -H 'sec-fetch-mode: cors' -H 'sec-fetch-dest: empty' -H 'referer: https://tv.naver.com/v/31030608' -H 'accept-language: en,zh-CN;q=0.9,zh;q=0.8')
+    local ts=$(date +%s%3N)
+    local base_url="https://apis.naver.com/"
+    local key="nbxvs5nwNG9QKEWK0ADjYA4JZoujF4gHcIwvoCxFTPAeamq5eemvt5IWAYXxrbYM"
+    local sign_text="https://apis.naver.com/now_web2/now_web_api/v1/clips/31030608/play-info${ts}"
+    local signature=$(printf "%s" "${sign_text}" | openssl dgst -sha1 -hmac "${key}" -binary | openssl base64)
+    local signature_encoded=$(printf "%s" "${signature}" | sed 's/ /%20/g;s/!/%21/g;s/"/%22/g;s/#/%23/g;s/\$/%24/g;s/\&/%26/g;s/'\''/%27/g;s/(/%28/g;s/)/%29/g;s/\*/%2a/g;s/+/%2b/g;s/,/%2c/g;s/\//%2f/g;s/:/%3a/g;s/;/%3b/g;s/=/%3d/g;s/?/%3f/g;s/@/%40/g;s/\[/%5b/g;s/\]/%5d/g')
+    local req_url="${base_url}now_web2/now_web_api/v1/clips/31030608/play-info?msgpad=${ts}&md=${signature_encoded}"
+    local tmpresult=$(curl $useNIC $usePROXY $xForward -${1} -s --max-time 10 "${req_url}" --user-agent "${UA_Browser}" -H 'host: apis.naver.com' -H 'connection: keep-alive' -H "sec-ch-ua: ${UA_SecCHUA}" -H 'accept: application/json, text/plain, */*' -H 'sec-ch-ua-mobile: ?0' -H 'sec-ch-ua-platform: "Windows"' -H 'origin: https://tv.naver.com' -H 'sec-fetch-site: same-site' -H 'sec-fetch-mode: cors' -H 'sec-fetch-dest: empty' -H 'referer: https://tv.naver.com/v/31030608' -H 'accept-language: en,zh-CN;q=0.9,zh;q=0.8')
     if [[ "$tmpresult" == "curl"* ]] && [ "$1" == "6" ]; then
         echo -n -e "\r Naver TV:\t\t\t\t${Font_Red}IPv6 Not Support${Font_Suffix}\n"
         return
@@ -2961,12 +2967,19 @@ function MediaUnlockTest_NaverTV() {
         echo -n -e "\r Naver TV:\t\t\t\t${Font_Red}Failed (Network Connection)${Font_Suffix}\n"
         return
     fi
-    local result=$(echo "$tmpresult" | python -m json.tool 2>/dev/null | grep ctry | cut -f4 -d'"')
-    if [[ "$result" == "KR" ]]; then
-        echo -n -e "\r Naver TV:\t\t\t\t${Font_Green}Yes${Font_Suffix}\n"
+    local playable=$(echo "$tmpresult" | python -m json.tool 2>/dev/null | grep -o '"playable": *"[^"]*"' | cut -d'"' -f4)
+
+    if [[ "$playable" == "NOT_COUNTRY_AVAILABLE" ]]; then
+        echo -n -e "\r Naver TV:\t\t\t\t${Font_Green}No${Font_Suffix}\n"
     else
-        echo -n -e "\r Naver TV:\t\t\t\t${Font_Red}No${Font_Suffix}\n"
+        echo -n -e "\r Naver TV:\t\t\t\t${Font_Red}Yes${Font_Suffix}\n"
     fi
+    # local result=$(echo "$tmpresult" | python -m json.tool 2>/dev/null | grep ctry | cut -f4 -d'"')
+    # if [[ "$result" == "KR" ]]; then
+    #     echo -n -e "\r Naver TV:\t\t\t\t${Font_Green}Yes${Font_Suffix}\n"
+    # else
+    #     echo -n -e "\r Naver TV:\t\t\t\t${Font_Red}No${Font_Suffix}\n"
+    # fi
 }
 
 function MediaUnlockTest_Afreeca() {
@@ -3865,13 +3878,13 @@ function KR_UnlockTest() {
         MediaUnlockTest_Watcha ${1} &
         MediaUnlockTest_CoupangPlay ${1} &
         MediaUnlockTest_SpotvNow ${1} &
-        # MediaUnlockTest_NaverTV ${1} &
+        MediaUnlockTest_NaverTV ${1} &
         MediaUnlockTest_Afreeca ${1} &
         MediaUnlockTest_KBSDomestic ${1} &
         # MediaUnlockTest_KOCOWA ${1} &
     )
     wait
-    local array=("Wavve:" "Tving:" "WATCHA:" "Coupang Play:" "SPOTV NOW" "Afreeca TV:" "KBS Domestic:")
+    local array=("Wavve:" "Tving:" "WATCHA:" "Coupang Play:" "Naver TV:" "SPOTV NOW" "Afreeca TV:" "KBS Domestic:")
     echo_Result ${result} ${array}
     echo "======================================="
 }


### PR DESCRIPTION
修复逻辑：

1. 当前时间戳 ts、基础 URL base_url、hamc算法的加密密钥 key、待签名的字符串 sign_text
2. 使用 openssl 命令根据 sign_text 和 key 计算 HMAC-SHA1 签名 signature，意味着需要安装openssl，这个大部分发行版自带，但是termux这种应该不行。
3. 将 signature签名后的字符串进行 Base64 编码并进行 URL 编码, 得到 signature_encoded。
4. 构建最终的请求 URL：req_url, 包含了时间戳和编码后的签名。
5. 使用 curl 命令发送 GET 请求到 req_url。
6. 使用 python 的json解析工具 json.tool 从 tmpresult 中提取 playable 字段的值。
7. 根据 playable的值判断是否解锁成功。如果值为 "NOT_COUNTRY_AVAILABLE",则输出 "No",否则输出 "Yes"。

本人不太会写bash的东西，那个url编码是gpt弄的，如果不严谨还请提出建议。