### PR TITLE
Dependency workaround for FreeBSD/macOS systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ apk add curl bash grep openssl ca-certificates uuidgen
 ### macOS:
 
 ```
-brew install curl openssl md5sha1sum coreutils
+brew install curl openssl grep
 ```
 
 ### Windows:

--- a/check.sh
+++ b/check.sh
@@ -79,11 +79,11 @@ resolve_ip_address() {
 
     if [ "$nslookupExists" == 1 ]; then
         if [ "$recordType" == 'AAAA' ]; then
-            local result=$(nslookup -q=AAAA "${domain}" | grep -woP "Address: \K[\d:a-f]+")
+            local result=$(nslookup -q=AAAA "${domain}" | $grep -woP "Address: \K[\d:a-f]+")
             echo "${result}"
             return
         else
-            local result=$(nslookup -q=A "${domain}" | grep -woP "Address: \K[\d.]+")
+            local result=$(nslookup -q=A "${domain}" | $grep -woP "Address: \K[\d.]+")
             echo "${result}"
             return
         fi
@@ -103,13 +103,13 @@ resolve_ip_address() {
     if [ "$recordType" == 'AAAA' ]; then
         local pingArgs='-6 -c 1 -w 1 -W 1'
         [ "$OS_ANDROID" == 1 ] && pingArgs='-c 1 -w 1 -W 1'
-        local result=$(ping6 ${pingArgs} "${domain}" 2>/dev/null | head -n 1 | grep -woP '\s\(\K[\d:a-f]+')
+        local result=$(ping6 ${pingArgs} "${domain}" 2>/dev/null | head -n 1 | $grep -woP '\s\(\K[\d:a-f]+')
         echo "${result}"
         return
     else
         local pingArgs='-4 -c 1 -w 1 -W 1'
         [ "$OS_ANDROID" == 1 ] && pingArgs='-c 1 -w 1 -W 1'
-        local result=$(ping ${pingArgs} "${domain}" 2>/dev/null | head -n 1 | grep -woP '\s\(\K[\d.]+')
+        local result=$(ping ${pingArgs} "${domain}" 2>/dev/null | head -n 1 | $grep -woP '\s\(\K[\d.]+')
         echo "${result}"
         return
     fi
@@ -121,13 +121,13 @@ validate_proxy() {
         exit 1
     fi
 
-    local tmpresult=$(echo "$1" | grep -P '^(socks|socks4|socks5|http)://([^:]+:[^@]+@)?(([0-9]{1,3}\.){3}[0-9]{1,3}|(\[[0-9a-fA-F:]+\]|([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|((([0-9a-fA-F]{1,4}:){1,6})|::(([0-9a-fA-F]{1,4}:){1,6}))([0-9a-fA-F]{1,4}))):(0|[1-9][0-9]{0,4})$')
+    local tmpresult=$(echo "$1" | $grep -P '^(socks|socks4|socks5|http)://([^:]+:[^@]+@)?(([0-9]{1,3}\.){3}[0-9]{1,3}|(\[[0-9a-fA-F:]+\]|([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|((([0-9a-fA-F]{1,4}:){1,6})|::(([0-9a-fA-F]{1,4}:){1,6}))([0-9a-fA-F]{1,4}))):(0|[1-9][0-9]{0,4})$')
     if [ -z "$tmpresult" ]; then
         echo -e "${Font_Red}Proxy IP invalid.${Font_Suffix}"
         exit 1
     fi
 
-    local port=$(echo "$1" | grep -woP ':\K[0-9]+$')
+    local port=$(echo "$1" | $grep -woP ':\K[0-9]+$')
     if [ "$port" -ge 65535 ]; then
         echo -e "${Font_Red}Proxy Port invalid.${Font_Suffix}"
         exit 1
@@ -140,10 +140,10 @@ validate_ip_address() {
         exit 1
     fi
 
-    if echo "$1" | awk '{$1=$1; print}' | grep -Eq '^([0-9]{1,3}\.){3}[0-9]{1,3}$'; then
+    if echo "$1" | awk '{$1=$1; print}' | $grep -Eq '^([0-9]{1,3}\.){3}[0-9]{1,3}$'; then
         return 4
     fi
-    echo "$1" | awk '{$1=$1; print}' | grep -Eq '^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$|^(([0-9a-fA-F]{1,4}:){1,7}|:):([0-9a-fA-F]{1,4}:){1,7}|:$|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}$|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}$|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}$|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}$|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}$|([0-9a-fA-F]{1,4}:){1}(:[0-9a-fA-F]{1,4}){1,6}$|:(:[0-9a-fA-F]{1,4}){1,7}$|((([0-9a-fA-F]{1,4}:){1,4}:|:):(([0-9a-fA-F]{1,4}:){0,1}[0-9a-fA-F]{1,4}){1,4})$'
+    echo "$1" | awk '{$1=$1; print}' | $grep -Eq '^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$|^(([0-9a-fA-F]{1,4}:){1,7}|:):([0-9a-fA-F]{1,4}:){1,7}|:$|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}$|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}$|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}$|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}$|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}$|([0-9a-fA-F]{1,4}:){1}(:[0-9a-fA-F]{1,4}){1,6}$|:(:[0-9a-fA-F]{1,4}){1,7}$|((([0-9a-fA-F]{1,4}:){1,4}:|:):(([0-9a-fA-F]{1,4}:){0,1}[0-9a-fA-F]{1,4}){1,4})$'
     if [ "$?" == 0 ]; then
         return 6
     fi
@@ -156,7 +156,7 @@ validate_intranet() {
         echo -e "${Font_Red}Param missing.${Font_Suffix}"
     fi
     # See https://en.wikipedia.org/wiki/Reserved_IP_addresses
-    local tmpresult=$(echo "$1" | grep -E '(^|\s)(10\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])|172\.(1[6-9]|2[0-9]|3[01])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])|192\.168\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])|100\.([6-9][4-9]|1[0-2][0-7])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])|169\.254\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])|192\.88\.99\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])|192\.0\.(0|2)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])|198\.(1[89])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])|198\.51\.100\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])|203\.0\.113\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])|2[23][4-9]\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])|233\.252\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])|(24[0-9]|25[0-5])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9]))(\s|$)')
+    local tmpresult=$(echo "$1" | $grep -E '(^|\s)(10\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])|172\.(1[6-9]|2[0-9]|3[01])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])|192\.168\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])|100\.([6-9][4-9]|1[0-2][0-7])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])|169\.254\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])|192\.88\.99\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])|192\.0\.(0|2)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])|198\.(1[89])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])|198\.51\.100\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])|203\.0\.113\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])|2[23][4-9]\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])|233\.252\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])|(24[0-9]|25[0-5])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9]))(\s|$)')
     if [ -z "$tmpresult" ]; then
         return 1
     fi
@@ -170,7 +170,7 @@ validate_region_id() {
         exit 1
     fi
     local regionid="$1"
-    local result=$(echo "$regionid" | grep -E '^[0-9]$|^1[0-1]$|^99$|^66$')
+    local result=$(echo "$regionid" | $grep -E '^[0-9]$|^1[0-1]$|^99$|^66$')
     if [ -z "$result" ]; then
         return 1
     fi
@@ -183,7 +183,7 @@ validate_net_type() {
         exit 1
     fi
     local netType="$1"
-    local result=$(echo "$netType" | grep -E '^4$|^6$|^0$')
+    local result=$(echo "$netType" | $grep -E '^4$|^6$|^0$')
     if [ -z "$result" ]; then
         echo -e "${Font_Red}Invalid Network Type.${Font_Suffix}"
         exit 1
@@ -226,6 +226,7 @@ check_net_connctivity() {
 
 check_os_type() {
     OS_TYPE=''
+    grep='grep'
     local ifLinux=$(uname -a | grep -i 'linux')
     local ifFreeBSD=$(uname -a | grep -i 'freebsd')
     local ifTermux=$(echo "$PWD" | grep -i 'termux')
@@ -249,6 +250,7 @@ check_os_type() {
     if [ -n "$ifMacOS" ]; then
         OS_TYPE='macos'
         OS_MACOS=1
+        grep='ggrep'
         return
     fi
     if [ -n "$ifMinGW" ]; then
@@ -264,6 +266,7 @@ check_os_type() {
     if [ -n "$ifFreeBSD" ]; then
         OS_TYPE='freebsd'
         OS_FREEBSD=1
+        grep='ggrep'
         return
     fi
     if [ -n "$ifAndroid" ]; then
@@ -319,8 +322,8 @@ check_dependencies() {
         esac
     fi
 
-    if [ -z $(echo 'e' | grep -P 'e' 2>/dev/null) ]; then
-        echo -e "${Font_Red}command 'grep' function is incomplete, please install the full version first.${Font_Suffix}"
+    if [ -z $(echo 'e' | $grep -P 'e' 2>/dev/null) ]; then
+        echo -e "${Font_Red}command '$grep' (GNU grep) function is incomplete, please install the full version first.${Font_Suffix}"
         exit 1
     fi
 
@@ -510,7 +513,7 @@ get_ip_info() {
         LOCAL_IP_ASTERISK=$(awk -F":" '{print $1":"$2":"$3":*:*"}' <<<"${local_ip}")
     fi
 
-    LOCAL_ISP=$(echo "$get_local_isp" | grep 'organization' | cut -f4 -d '"')
+    LOCAL_ISP=$(echo "$get_local_isp" | $grep 'organization' | cut -f4 -d '"')
 }
 
 show_region() {
@@ -529,7 +532,7 @@ function GameTest_Steam() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep 'priceCurrency' | cut -d '"' -f4)
+    local result=$(echo "$tmpresult" | $grep 'priceCurrency' | cut -d '"' -f4)
     if [ -z "$result" ]; then
         echo -n -e "\r Steam Currency:\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
         return
@@ -552,7 +555,7 @@ function MediaUnlockTest_BahamutAnime() {
         return
     fi
 
-    local tempdeviceid=$(echo "$tmpresult" | grep -woP '"deviceid"\s{0,}:\s{0,}"\K[^"]+')
+    local tempdeviceid=$(echo "$tmpresult" | $grep -woP '"deviceid"\s{0,}:\s{0,}"\K[^"]+')
     # I Was Reincarnated as the 7th Prince
     local sn='37783'
     local tmpresult1=$(curl ${CURL_DEFAULT_OPTS} -sL "https://ani.gamer.com.tw/ajax/token.php?adID=89422&sn=${sn}&device=${tempdeviceid}" -b bahamut_cookie.txt --user-agent "${UA_BROWSER}")
@@ -563,14 +566,14 @@ function MediaUnlockTest_BahamutAnime() {
         return
     fi
 
-    local result=$(echo "$tmpresult1" | grep 'animeSn')
+    local result=$(echo "$tmpresult1" | $grep 'animeSn')
 
     if [ -z "$result" ]; then
         echo -n -e "\r Bahamut Anime:\t\t\t\t${Font_Red}No${Font_Suffix}\n"
         return
     fi
 
-    local region=$(echo "$tmpresult2" | grep -woP 'data-geo="\K[^"]+')
+    local region=$(echo "$tmpresult2" | $grep -woP 'data-geo="\K[^"]+')
     if [ -n "$region" ]; then
         echo -n -e "\r Bahamut Anime:\t\t\t\t${Font_Green}Yes (Region: ${region})${Font_Suffix}\n"
         return
@@ -594,7 +597,7 @@ function MediaUnlockTest_BilibiliChinaMainland() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"code"\s{0,}:\s{0,}\K[-\d]+' | head -n 1)
+    local result=$(echo "$tmpresult" | $grep -woP '"code"\s{0,}:\s{0,}\K[-\d]+' | head -n 1)
     case "$result" in
         '0') echo -n -e "\r BiliBili China Mainland Only:\t\t${Font_Green}Yes${Font_Suffix}\n" ;;
         '-10403') echo -n -e "\r BiliBili China Mainland Only:\t\t${Font_Red}No${Font_Suffix}\n" ;;
@@ -617,7 +620,7 @@ function MediaUnlockTest_BilibiliHKMCTW() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"code"\s{0,}:\s{0,}\K[-\d]+' | head -n 1)
+    local result=$(echo "$tmpresult" | $grep -woP '"code"\s{0,}:\s{0,}\K[-\d]+' | head -n 1)
     case "$result" in
         '0') echo -n -e "\r BiliBili Hongkong/Macau/Taiwan:\t${Font_Green}Yes${Font_Suffix}\n" ;;
         '-10403') echo -n -e "\r BiliBili Hongkong/Macau/Taiwan:\t${Font_Red}No${Font_Suffix}\n" ;;
@@ -640,7 +643,7 @@ function MediaUnlockTest_BilibiliTW() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"code"\s{0,}:\s{0,}\K[-\d]+' | head -n 1)
+    local result=$(echo "$tmpresult" | $grep -woP '"code"\s{0,}:\s{0,}\K[-\d]+' | head -n 1)
     case "$result" in
         '0') echo -n -e "\r Bilibili Taiwan Only:\t\t\t${Font_Green}Yes${Font_Suffix}\n" ;;
         '-10403') echo -n -e "\r Bilibili Taiwan Only:\t\t\t${Font_Red}No${Font_Suffix}\n" ;;
@@ -660,7 +663,7 @@ function MediaUnlockTest_AbemaTV() {
         return
     fi
 
-    local region=$(echo "$tmpresult" | grep -woP '"isoCountryCode"\s{0,}:\s{0,}"\K[^"]+')
+    local region=$(echo "$tmpresult" | $grep -woP '"isoCountryCode"\s{0,}:\s{0,}"\K[^"]+')
     if [ -z "$region" ]; then
         echo -n -e "\r Abema.TV:\t\t\t\t${Font_Red}No${Font_Suffix}\n"
         return
@@ -771,8 +774,8 @@ function MediaUnlockTest_BBCiPLAYER() {
         return
     fi
 
-    local isBlocked=$(echo "$tmpresult" | grep -i 'geolocation')
-    local isOK=$(echo "$tmpresult" | grep -i 'vs-hls-push-uk')
+    local isBlocked=$(echo "$tmpresult" | $grep -i 'geolocation')
+    local isOK=$(echo "$tmpresult" | $grep -i 'vs-hls-push-uk')
 
     if [ -z "$isBlocked" ] && [ -z "$isOK" ]; then
         echo -n -e "\r BBC iPLAYER:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -810,7 +813,7 @@ function MediaUnlockTest_Netflix() {
     fi
     if [ "$result1" == '200' ] || [ "$result2" == '200' ]; then
         local tmpresult=$(curl ${CURL_DEFAULT_OPTS} -sL 'https://www.netflix.com/' -H 'accept-language: en-US,en;q=0.9' -H "sec-ch-ua: ${UA_SEC_CH_UA}" -H 'sec-ch-ua-mobile: ?0' -H 'sec-ch-ua-platform: "Windows"' -H 'sec-fetch-site: none' -H 'sec-fetch-mode: navigate' -H 'sec-fetch-user: ?1' -H 'sec-fetch-dest: document' --user-agent "${UA_BROWSER}")
-        local region=$(echo "$tmpresult" | grep -woP '"requestCountry":{"id":"\K\w\w' | head -n 1)
+        local region=$(echo "$tmpresult" | $grep -woP '"requestCountry":{"id":"\K\w\w' | head -n 1)
         echo -n -e "\r Netflix:\t\t\t\t${Font_Green}Yes (Region: ${region})${Font_Suffix}\n"
         return
     fi
@@ -830,13 +833,13 @@ function MediaUnlockTest_DisneyPlus() {
         return
     fi
 
-    local is403=$(echo "$tempresult" | grep -i '403 ERROR')
+    local is403=$(echo "$tempresult" | $grep -i '403 ERROR')
     if [ -n "$is403" ]; then
         echo -n -e "\r Disney+:\t\t\t\t${Font_Red}No (IP Banned By Disney+)${Font_Suffix}\n"
         return
     fi
 
-    local assertion=$(echo "$tempresult" | grep -woP '"assertion"\s{0,}:\s{0,}"\K[^"]+')
+    local assertion=$(echo "$tempresult" | $grep -woP '"assertion"\s{0,}:\s{0,}"\K[^"]+')
     if [ -z "$assertion" ]; then
         echo -n -e "\r Disney+:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
         return
@@ -846,8 +849,8 @@ function MediaUnlockTest_DisneyPlus() {
     local disneyCookie=$(echo "$preDisneyCookie" | sed "s/DISNEYASSERTION/${assertion}/g")
     local tokenContent=$(curl ${CURL_DEFAULT_OPTS} -s 'https://disney.api.edge.bamgrid.com/token' -X POST -H "authorization: Bearer ZGlzbmV5JmJyb3dzZXImMS4wLjA.Cu56AgSfBTDag5NiRA81oLHkDZfu5L3CKadnefEAY84" -d "${disneyCookie}" --user-agent "${UA_BROWSER}")
 
-    local isBlocked=$(echo "$tokenContent" | grep -i 'forbidden-location')
-    local is403=$(echo "$tokenContent" | grep -i '403 ERROR')
+    local isBlocked=$(echo "$tokenContent" | $grep -i 'forbidden-location')
+    local is403=$(echo "$tokenContent" | $grep -i '403 ERROR')
 
     if [ -n "$isBlocked" ] || [ -n "$is403" ]; then
         echo -n -e "\r Disney+:\t\t\t\t${Font_Red}No (IP Banned By Disney+ 1)${Font_Suffix}\n"
@@ -855,14 +858,14 @@ function MediaUnlockTest_DisneyPlus() {
     fi
 
     local fakeContent=$(echo "$MEDIA_COOKIE" | sed -n '8p')
-    local refreshToken=$(echo "$tokenContent" | grep -woP '"refresh_token"\s{0,}:\s{0,}"\K[^"]+')
+    local refreshToken=$(echo "$tokenContent" | $grep -woP '"refresh_token"\s{0,}:\s{0,}"\K[^"]+')
     local disneyContent=$(echo "$fakeContent" | sed "s/ILOVEDISNEY/${refreshToken}/g")
     local tmpresult=$(curl ${CURL_DEFAULT_OPTS} -sL 'https://disney.api.edge.bamgrid.com/graph/v1/device/graphql' -X POST -H "authorization: ZGlzbmV5JmJyb3dzZXImMS4wLjA.Cu56AgSfBTDag5NiRA81oLHkDZfu5L3CKadnefEAY84" -d "${disneyContent}" --user-agent "${UA_BROWSER}")
 
     local previewcheck=$(curl ${CURL_DEFAULT_OPTS} -sL 'https://disneyplus.com' -w '%{url_effective}\n' -o /dev/null --user-agent "${UA_BROWSER}")
-    local isUnavailable=$(echo "$previewcheck" | grep -E 'preview|unavailable')
-    local region=$(echo "$tmpresult" | grep -woP '"countryCode"\s{0,}:\s{0,}"\K[^"]+')
-    local inSupportedLocation=$(echo "$tmpresult" | grep -woP '"inSupportedLocation"\s{0,}:\s{0,}\K(false|true)')
+    local isUnavailable=$(echo "$previewcheck" | $grep -E 'preview|unavailable')
+    local region=$(echo "$tmpresult" | $grep -woP '"countryCode"\s{0,}:\s{0,}"\K[^"]+')
+    local inSupportedLocation=$(echo "$tmpresult" | $grep -woP '"inSupportedLocation"\s{0,}:\s{0,}\K(false|true)')
 
     if [ -z "$region" ]; then
         echo -n -e "\r Disney+:\t\t\t\t${Font_Red}No${Font_Suffix}\n"
@@ -900,8 +903,8 @@ function MediaUnlockTest_Dazn() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"isAllowed"\s{0,}:\s{0,}\K(false|true)')
-    local region=$(echo "$tmpresult" | grep -woP '"GeolocatedCountry"\s{0,}:\s{0,}"\K[^"]+' | tr a-z A-Z)
+    local result=$(echo "$tmpresult" | $grep -woP '"isAllowed"\s{0,}:\s{0,}\K(false|true)')
+    local region=$(echo "$tmpresult" | $grep -woP '"GeolocatedCountry"\s{0,}:\s{0,}"\K[^"]+' | tr a-z A-Z)
     case "$result" in
         'false') echo -n -e "\r Dazn:\t\t\t\t\t${Font_Red}No${Font_Suffix}\n" ;;
         'true') echo -n -e "\r Dazn:\t\t\t\t\t${Font_Green}Yes (Region: ${region})${Font_Suffix}\n" ;;
@@ -924,7 +927,7 @@ function MediaUnlockTest_HuluJP() {
     fi
 
     local urlEffective=$(echo "$tmpresult" | awk -F'_TAG_' '{print $2}')
-    local isBlocked=$(echo "$urlEffective" | grep 'restrict')
+    local isBlocked=$(echo "$urlEffective" | $grep 'restrict')
 
     if [ -n "$isBlocked" ]; then
         echo -n -e "\r Hulu Japan:\t\t\t\t${Font_Red}No${Font_Suffix}\n"
@@ -954,7 +957,7 @@ function MediaUnlockTest_MyTVSuper() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"country_code"\s{0,}:\s{0,}"\K[^"]+')
+    local result=$(echo "$tmpresult" | $grep -woP '"country_code"\s{0,}:\s{0,}"\K[^"]+')
     if [ "$result" == 'HK' ]; then
         echo -n -e "\r MyTVSuper:\t\t\t\t${Font_Green}Yes${Font_Suffix}\n"
         return
@@ -978,7 +981,7 @@ function MediaUnlockTest_NowE() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"responseCode"\s{0,}:\s{0,}"\K[^"]+')
+    local result=$(echo "$tmpresult" | $grep -woP '"responseCode"\s{0,}:\s{0,}"\K[^"]+')
     case "$result" in
         'GEO_CHECK_FAIL') echo -n -e "\r Now E:\t\t\t\t\t${Font_Red}No${Font_Suffix}\n" ;;
         'SUCCESS') echo -n -e "\r Now E:\t\t\t\t\t${Font_Green}Yes${Font_Suffix}\n" ;;
@@ -998,7 +1001,7 @@ function MediaUnlockTest_ViuTV() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"responseCode"\s{0,}:\s{0,}"\K[^"]+')
+    local result=$(echo "$tmpresult" | $grep -woP '"responseCode"\s{0,}:\s{0,}"\K[^"]+')
     case "$result" in
         'GEO_CHECK_FAIL') echo -n -e "\r Viu.TV:\t\t\t\t${Font_Red}No${Font_Suffix}\n" ;;
         'SUCCESS') echo -n -e "\r Viu.TV:\t\t\t\t${Font_Green}Yes${Font_Suffix}\n" ;;
@@ -1013,7 +1016,7 @@ function MediaUnlockTest_unext() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"resultStatus"\s{0,}:\s{0,}\K\d+')
+    local result=$(echo "$tmpresult" | $grep -woP '"resultStatus"\s{0,}:\s{0,}\K\d+')
     case "$result" in
         '475') echo -n -e "\r U-NEXT:\t\t\t\t${Font_Green}Yes${Font_Suffix}\n" ;;
         '200') echo -n -e "\r U-NEXT:\t\t\t\t${Font_Green}Yes${Font_Suffix}\n" ;;
@@ -1036,7 +1039,7 @@ function MediaUnlockTest_wowow() {
         return
     fi
     # 取无料剧集来播放 example: https://www.wowow.co.jp/drama/original/hakubo/
-    local playUrlList=$(echo "$tmpresult" | grep -woP '"link"\s{0,}:\s{0,}"\K[^"]+' | grep 'drama/original' | head -n 4 | xargs)
+    local playUrlList=$(echo "$tmpresult" | $grep -woP '"link"\s{0,}:\s{0,}"\K[^"]+' | $grep 'drama/original' | head -n 4 | xargs)
     if [ -z "$playUrlList" ]; then
         echo -n -e "\r WOWOW:\t\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
         return
@@ -1051,7 +1054,7 @@ function MediaUnlockTest_wowow() {
         fi
 
         # 取得真实链接
-        local wodUrl=$(echo "$tmpresult2" | grep -o '"https://wod.wowow.co.jp/content/.*"' | cut -f2 -d'"' | head -n 1)
+        local wodUrl=$(echo "$tmpresult2" | $grep -o '"https://wod.wowow.co.jp/content/.*"' | cut -f2 -d'"' | head -n 1)
         if [ -n "$wodUrl" ]; then
             break
         fi
@@ -1070,7 +1073,7 @@ function MediaUnlockTest_wowow() {
         return
     fi
 
-    local metaId=$(echo "$tmpresult3" | grep -woP '"https://wod.wowow.co.jp/watch/\K\d{0,}[^"]+')
+    local metaId=$(echo "$tmpresult3" | $grep -woP '"https://wod.wowow.co.jp/watch/\K\d{0,}[^"]+')
     # Fake Vistor UID
     local vUid=$(echo -n "$timestamp" | md5sum | cut -f1 -d' ')
     # 最终测试
@@ -1079,8 +1082,8 @@ function MediaUnlockTest_wowow() {
         echo -n -e "\r WOWOW:\t\t\t\t\t${Font_Red}Failed (Network Connection 3)${Font_Suffix}\n"
         return
     fi
-    local isBlocked=$(echo "$tmpresult4" | grep -i 'VPN')
-    local isOK=$(echo "$tmpresult4" | grep -i 'playback_session_id')
+    local isBlocked=$(echo "$tmpresult4" | $grep -i 'VPN')
+    local isOK=$(echo "$tmpresult4" | $grep -i 'playback_session_id')
 
     if [ -z "$isBlocked" ] && [ -z "$isOK" ]; then
         echo -n -e "\r WOWOW:\t\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR 2)${Font_Suffix}\n"
@@ -1111,8 +1114,8 @@ function MediaUnlockTest_TVer() {
         return
     fi
     # 先取 UID 和 TOKEN
-    local platformUid=$(echo "$tmpresult" | grep -woP '"platform_uid"\s{0,}:\s{0,}"\K[^"]+')
-    local platformToken=$(echo "$tmpresult" | grep -woP '"platform_token"\s{0,}:\s{0,}"\K[^"]+')
+    local platformUid=$(echo "$tmpresult" | $grep -woP '"platform_uid"\s{0,}:\s{0,}"\K[^"]+')
+    local platformToken=$(echo "$tmpresult" | $grep -woP '"platform_token"\s{0,}:\s{0,}"\K[^"]+')
     # 根据 UID 和 TOKEN 取得当前正在播放的剧集
     local tmpresult2=$(curl ${CURL_DEFAULT_OPTS} -s "https://platform-api.tver.jp/service/api/v1/callHome?platform_uid=${platformUid}&platform_token=${platformToken}&require_data=mylist%2Cresume%2Clater" -H 'origin: https://tver.jp' -H 'referer: https://tver.jp/' -H 'accept-language: en-US,en;q=0.9' -H "sec-ch-ua: ${UA_SEC_CH_UA}" -H 'sec-ch-ua-mobile: ?0' -H 'sec-ch-ua-platform: "Windows"' -H 'sec-fetch-dest: empty' -H 'sec-fetch-mode: cors' -H 'sec-fetch-site: same-site' -H 'x-tver-platform-type: web' --user-agent "${UA_BROWSER}")
     if [ -z "$tmpresult2" ]; then
@@ -1121,7 +1124,7 @@ function MediaUnlockTest_TVer() {
     fi
     # 返回结果取新电视剧第一个值
     # echo "$tmpresult2" | jq  -r '.result.components.[] | select(.componentID | contains("newer-drama")) | limit(1; .contents.[].content.id)'
-    local episodeId=$(echo "$tmpresult2" | sed -E 's/.*"newer-drama([.]{0,})"//' | sed 's/"componentID".*//' | sed 's/"id"/_TAG_/;s/.*_TAG_//' | cut -f2 -d'"' | grep -E '[a-z0-9]{10}')
+    local episodeId=$(echo "$tmpresult2" | sed -E 's/.*"newer-drama([.]{0,})"//' | sed 's/"componentID".*//' | sed 's/"id"/_TAG_/;s/.*_TAG_//' | cut -f2 -d'"' | $grep -E '[a-z0-9]{10}')
     if [ -z "$episodeId" ]; then
         echo -n -e "\r TVer:\t\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
         return
@@ -1134,10 +1137,10 @@ function MediaUnlockTest_TVer() {
         return
     fi
     # 取 accountID / playerID / videoID / videoRefID
-    local accountID=$(echo "$tmpresult3" | grep -woP '"accountID"\s{0,}:\s{0,}"\K[^"]+')
-    local playerID=$(echo "$tmpresult3" | grep -woP '"playerID"\s{0,}:\s{0,}"\K[^"]+')
-    local videoID=$(echo "$tmpresult3" | grep -woP '"videoID"\s{0,}:\s{0,}"\K[^"]+')
-    local videoRefID=$(echo "$tmpresult3" | grep -woP '"videoRefID"\s{0,}:\s{0,}"\K[^"]+')
+    local accountID=$(echo "$tmpresult3" | $grep -woP '"accountID"\s{0,}:\s{0,}"\K[^"]+')
+    local playerID=$(echo "$tmpresult3" | $grep -woP '"playerID"\s{0,}:\s{0,}"\K[^"]+')
+    local videoID=$(echo "$tmpresult3" | $grep -woP '"videoID"\s{0,}:\s{0,}"\K[^"]+')
+    local videoRefID=$(echo "$tmpresult3" | $grep -woP '"videoRefID"\s{0,}:\s{0,}"\K[^"]+')
     # 取得 brightcove 播放器信息
     local tmpresult4=$(curl ${CURL_DEFAULT_OPTS} -s "https://players.brightcove.net/${accountID}/${playerID}_default/index.min.js" -H 'Referer: https://tver.jp/' -H 'Sec-Fetch-Dest: script' -H 'Sec-Fetch-Mode: no-cors' -H 'Sec-Fetch-Site: cross-site' -H 'accept-language: en-US,en;q=0.9' -H "sec-ch-ua: ${UA_SEC_CH_UA}" -H 'sec-ch-ua-mobile: ?0' -H 'sec-ch-ua-platform: "Windows"' --user-agent "${UA_BROWSER}")
     if [ -z "$tmpresult4" ]; then
@@ -1161,7 +1164,7 @@ function MediaUnlockTest_TVer() {
         echo -n -e "\r TVer:\t\t\t\t\t${Font_Red}Failed (Network Connection 4)${Font_Suffix}\n"
         return
     fi
-    local result=$(echo "$tmpresult5" | grep -woP '"error_subcode"\s{0,}:\s{0,}"\K[^"]+')
+    local result=$(echo "$tmpresult5" | $grep -woP '"error_subcode"\s{0,}:\s{0,}"\K[^"]+')
     case "$result" in
         'CLIENT_GEO') echo -n -e "\r TVer:\t\t\t\t\t${Font_Red}No${Font_Suffix}\n" ;;
         '') echo -n -e "\r TVer:\t\t\t\t\t${Font_Green}Yes${Font_Suffix}\n" ;;
@@ -1181,7 +1184,7 @@ function MediaUnlockTest_HamiVideo() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"code"\s{0,}:\s{0,}"\K[^"]+')
+    local result=$(echo "$tmpresult" | $grep -woP '"code"\s{0,}:\s{0,}"\K[^"]+')
     case "$result" in
         '06001-106') echo -n -e "\r Hami Video:\t\t\t\t${Font_Red}No${Font_Suffix}\n" ;;
         '06001-107') echo -n -e "\r Hami Video:\t\t\t\t${Font_Green}Yes${Font_Suffix}\n" ;;
@@ -1201,7 +1204,7 @@ function MediaUnlockTest_4GTV() {
         return
     fi
 
-    result=$(echo "$tmpresult" | grep -woP '"Data"\s{0,}:\s{0,}"\K[^"]+')
+    result=$(echo "$tmpresult" | $grep -woP '"Data"\s{0,}:\s{0,}"\K[^"]+')
     case "$result" in
         'N') echo -n -e "\r 4GTV.TV:\t\t\t\t${Font_Red}No${Font_Suffix}\n" ;;
         'Y') echo -n -e "\r 4GTV.TV:\t\t\t\t${Font_Green}Yes${Font_Suffix}\n" ;;
@@ -1219,7 +1222,7 @@ function MediaUnlockTest_SlingTV() {
     fi
 
     local urlEffective=$(echo "$tmpresult" | awk -F'_TAG_' '{print $2}')
-    local isBlocked=$(echo "$urlEffective" | grep -i 'geo-block')
+    local isBlocked=$(echo "$urlEffective" | $grep -i 'geo-block')
 
     if [ -n "$isBlocked" ]; then
         echo -n -e "\r Sling TV:\t\t\t\t${Font_Red}No${Font_Suffix}\n"
@@ -1248,7 +1251,7 @@ function MediaUnlockTest_PlutoTV() {
     fi
 
     local urlEffective=$(echo "$tmpresult" | awk -F'_TAG_' '{print $2}')
-    local isBlocked=$(echo "$urlEffective" | grep 'plutotv-is-not-available')
+    local isBlocked=$(echo "$urlEffective" | $grep 'plutotv-is-not-available')
 
     if [ -n "$isBlocked" ]; then
         echo -n -e "\r Pluto TV:\t\t\t\t${Font_Red}No${Font_Suffix}\n"
@@ -1264,16 +1267,16 @@ function MediaUnlockTest_PlutoTV() {
 
 function MediaUnlockTest_HBOMax() {
     local tmpresult=$(curl ${CURL_DEFAULT_OPTS} -sLi 'https://www.max.com/' -w "_TAG_%{http_code}_TAG_" --user-agent "${UA_BROWSER}")
-    local httpCode=$(echo "$tmpresult" | grep '_TAG_' | awk -F'_TAG_' '{print $2}')
+    local httpCode=$(echo "$tmpresult" | $grep '_TAG_' | awk -F'_TAG_' '{print $2}')
     if [ "$httpCode" == '000' ]; then
         echo -n -e "\r HBO Max:\t\t\t\t${Font_Red}Failed (Network Connection)${Font_Suffix}\n"
         return
     fi
 
-    local countryList=$(echo "$tmpresult" | grep -woP '"url":"/[a-z]{2}/[a-z]{2}"' | cut -f4 -d'"' | cut -f2 -d'/' | sort -n | uniq | xargs | tr a-z A-Z)
+    local countryList=$(echo "$tmpresult" | $grep -woP '"url":"/[a-z]{2}/[a-z]{2}"' | cut -f4 -d'"' | cut -f2 -d'/' | sort -n | uniq | xargs | tr a-z A-Z)
     local countryList="${countryList} US"
-    local region=$(echo "$tmpresult" | grep -woP 'countryCode=\K[A-Z]{2}' | head -n 1)
-    local isUnavailable=$(echo "$countryList" | grep "$region")
+    local region=$(echo "$tmpresult" | $grep -woP 'countryCode=\K[A-Z]{2}' | head -n 1)
+    local isUnavailable=$(echo "$countryList" | $grep "$region")
 
     if [ -z "$region" ]; then
         echo -n -e "\r HBO Max:\t\t\t\t${Font_Red}Failed (Error: Country Code Not Found)${Font_Suffix}\n"
@@ -1289,16 +1292,16 @@ function MediaUnlockTest_HBOMax() {
 
 function MediaUnlockTest_Showmax() {
     local tmpresult=$(curl ${CURL_DEFAULT_OPTS} -sLi 'https://www.showmax.com/' -w "_TAG_%{http_code}_TAG_" -H 'host: www.showmax.com' -H 'accept-language: en-US,en;q=0.9' -H "sec-ch-ua: ${UA_SEC_CH_UA}" -H 'sec-ch-ua-mobile: ?0' -H 'sec-ch-ua-platform: "Windows"' -H 'upgrade-insecure-requests: 1' -H 'accept: */*;q=0.8,application/signed-exchange;v=b3;q=0.7' -H 'accept-language: en-US,en;q=0.9' -H 'sec-fetch-site: none' -H 'sec-fetch-mode: navigate' -H 'sec-fetch-user: ?1' -H 'sec-fetch-dest: document' --user-agent "${UA_BROWSER}")
-    local httpCode=$(echo "$tmpresult" | grep '_TAG_' | awk -F'_TAG_' '{print $2}')
+    local httpCode=$(echo "$tmpresult" | $grep '_TAG_' | awk -F'_TAG_' '{print $2}')
 
     if [ "$httpCode" == '000' ]; then
         echo -n -e "\r Showmax:\t\t\t\t${Font_Red}Failed (Network Connection)${Font_Suffix}\n"
         return
     fi
 
-    local isBlocked=$(echo "$tmpresult" | grep 'is unavailable in this location')
-    local isOK=$(echo "$tmpresult" | grep -i 'Streaming for Africa')
-    local region=$(echo "$tmpresult" | grep -woP 'activeTerritory=\K[A-Z]+' | head -n 1)
+    local isBlocked=$(echo "$tmpresult" | $grep 'is unavailable in this location')
+    local isOK=$(echo "$tmpresult" | $grep -i 'Streaming for Africa')
+    local region=$(echo "$tmpresult" | $grep -woP 'activeTerritory=\K[A-Z]+' | head -n 1)
 
     if [ -z "$isBlocked" ] && [ -z "$isOK" ]; then
         echo -n -e "\r Showmax:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -1344,8 +1347,8 @@ function MediaUnlockTest_ITVHUB() {
         return
     fi
 
-    local isBlocked=$(echo "$tmpresult" | grep -i 'Outside Of Allowed Geographic')
-    local isOK=$(echo "$tmpresult" | grep -i 'Playlist')
+    local isBlocked=$(echo "$tmpresult" | $grep -i 'Outside Of Allowed Geographic')
+    local isOK=$(echo "$tmpresult" | $grep -i 'Playlist')
 
     if [ -z "$isBlocked" ] && [ -z "$isOK" ]; then
         echo -n -e "\r ITV Hub:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -1387,13 +1390,13 @@ function RegionTest_iQYI() {
 
     local tmpresult=$(curl ${CURL_DEFAULT_OPTS} -sL 'https://www.iq.com/' -w "_TAG_%{http_code}_TAG_" -o /dev/null --user-agent "${UA_BROWSER}" -D -)
 
-    local httpCode=$(echo "$tmpresult" | grep '_TAG_' | awk -F'_TAG_' '{print $2}')
+    local httpCode=$(echo "$tmpresult" | $grep '_TAG_' | awk -F'_TAG_' '{print $2}')
     if [ "$httpCode" == '000' ]; then
         echo -n -e "\r iQyi Oversea Region:\t\t\t${Font_Red}Failed (Network Connection)${Font_Suffix}\n"
         return
     fi
 
-    local region=$(echo "$tmpresult" | grep -woP 'mod=\K[a-z]+' | tr a-z A-Z)
+    local region=$(echo "$tmpresult" | $grep -woP 'mod=\K[a-z]+' | tr a-z A-Z)
     if [ -z "$region" ]; then
         echo -n -e "\r iQyi Oversea Region:\t\t\t${Font_Red}Failed (Error: Country Code Not Found)${Font_Suffix}\n"
         return
@@ -1413,7 +1416,7 @@ function MediaUnlockTest_HuluUS() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"name"\s{0,}:\s{0,}"\K[^"]+')
+    local result=$(echo "$tmpresult" | $grep -woP '"name"\s{0,}:\s{0,}"\K[^"]+')
     case "$result" in
         'LOGIN_FORBIDDEN') echo -n -e "\r Hulu:\t\t\t\t\t${Font_Green}Yes${Font_Suffix}\n" ;;
         'GEO_BLOCKED') echo -n -e "\r Hulu:\t\t\t\t\t${Font_Red}No${Font_Suffix}\n" ;;
@@ -1434,7 +1437,7 @@ function MediaUnlockTest_encoreTVB() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"error_subcode"\s{0,}:\s{0,}"\K[^"]+')
+    local result=$(echo "$tmpresult" | $grep -woP '"error_subcode"\s{0,}:\s{0,}"\K[^"]+')
     case "$result" in
         'CLIENT_GEO') echo -n -e "\r encoreTVB:\t\t\t\t${Font_Red}No${Font_Suffix}\n" ;;
         '') echo -n -e "\r encoreTVB:\t\t\t\t${Font_Green}Yes${Font_Suffix}\n" ;;
@@ -1449,7 +1452,7 @@ function MediaUnlockTest_Molotov() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"is_france"\s{0,}:\s{0,}\K(false|true)')
+    local result=$(echo "$tmpresult" | $grep -woP '"is_france"\s{0,}:\s{0,}\K(false|true)')
 
     case "$result" in
         'false') echo -n -e "\r Molotov:\t\t\t\t${Font_Red}No${Font_Suffix}\n" ;;
@@ -1471,7 +1474,7 @@ function MediaUnlockTest_LineTVTW() {
         return
     fi
     # 找 main js 的链接
-    local mainJsUrl=$(echo "$tmpresult" | grep -woP 'src="\K[^"]+' | grep -E '/main-[a-z0-9]{8}')
+    local mainJsUrl=$(echo "$tmpresult" | $grep -woP 'src="\K[^"]+' | $grep -E '/main-[a-z0-9]{8}')
     # 下载 main js
     local tmpresult2=$(curl ${CURL_DEFAULT_OPTS} -s "${mainJsUrl}" -H 'referer: https://www.linetv.tw/' --user-agent "${UA_BROWSER}")
     if [ -z "$tmpresult2" ]; then
@@ -1479,7 +1482,7 @@ function MediaUnlockTest_LineTVTW() {
         return
     fi
     # 从 main js 里找 appId
-    local appId=$(echo "$tmpresult2" | grep -woP 'appId:"\K[^"]+' | head -n 1)
+    local appId=$(echo "$tmpresult2" | $grep -woP 'appId:"\K[^"]+' | head -n 1)
     # 正式测试
     local tmpresult3=$(curl ${CURL_DEFAULT_OPTS} -s "https://www.linetv.tw/api/part/11829/eps/1/part?appId=${appId}&productType=FAST&version=10.38.0" --user-agent "${UA_BROWSER}")
     if [ -z "$tmpresult3" ]; then
@@ -1487,7 +1490,7 @@ function MediaUnlockTest_LineTVTW() {
         return
     fi
 
-    local result=$(echo "$tmpresult3" | grep -woP '"countryCode"\s{0,}:\s{0,}\K\d+')
+    local result=$(echo "$tmpresult3" | $grep -woP '"countryCode"\s{0,}:\s{0,}\K\d+')
     case "$result" in
         '228') echo -n -e "\r LineTV.TW:\t\t\t\t${Font_Green}Yes${Font_Suffix}\n" ;;
         '') echo -n -e "\r LineTV.TW:\t\t\t\t${Font_Red}Failed (Error: Country Code Not Found)${Font_Suffix}\n" ;;
@@ -1546,9 +1549,9 @@ function MediaUnlockTest_Niconico() {
     fi
 
     # 从直播网页中找到第一个官方直播剧
-    # echo "$tmpresult2" | grep -woP 'id="DAT-csr-data" data-value="[^"]+' | sed 's/id="DAT-csr-data" data-value="//;s/&quot;/"/g' | \
+    # echo "$tmpresult2" | $grep -woP 'id="DAT-csr-data" data-value="[^"]+' | sed 's/id="DAT-csr-data" data-value="//;s/&quot;/"/g' | \
     # jq -r '.props.view.popularBeforeOpenBroadcastStatusProgramListSectionState.programList.[] | select(.isOfficialChannelMemberFree == false) | .id' | head -n 1
-    local liveID=$(echo "$tmpresult2" | sed 's/&quot;isOfficialChannelMemberFree&quot;:false/&quot;isOfficialChannelMemberFree&quot;:false\r\n/g' | grep -v '&quot;isOfficialChannelMemberFree&quot;:true' | grep -v -E 'playerProgram|&quot;ON_AIR&quot;' | grep '話' | grep -woP '&quot;id&quot;:&quot;\Klv[0-9]+' | head -n 1)
+    local liveID=$(echo "$tmpresult2" | sed 's/&quot;isOfficialChannelMemberFree&quot;:false/&quot;isOfficialChannelMemberFree&quot;:false\r\n/g' | $grep -v '&quot;isOfficialChannelMemberFree&quot;:true' | $grep -v -E 'playerProgram|&quot;ON_AIR&quot;' | $grep '話' | $grep -woP '&quot;id&quot;:&quot;\Klv[0-9]+' | head -n 1)
     if [ -z "$liveID" ]; then
         echo -n -e "\r Niconico:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
         return
@@ -1560,8 +1563,8 @@ function MediaUnlockTest_Niconico() {
         return
     fi
 
-    local isBlocked=$(echo "$tmpresult" | grep '同じ地域')
-    local isJapanOnly=$(echo "$tmpresult3" | grep 'notAllowedCountry')
+    local isBlocked=$(echo "$tmpresult" | $grep '同じ地域')
+    local isJapanOnly=$(echo "$tmpresult3" | $grep 'notAllowedCountry')
 
     if [ -z "$isBlocked" ] && [ -z "$isJapanOnly" ]; then
         echo -n -e "\r Niconico:\t\t\t\t${Font_Green}Yes (LiveID: $liveID)${Font_Suffix}\n"
@@ -1619,7 +1622,7 @@ function MediaUnlockTest_KKTV() {
         return
     fi
 
-    result=$(echo "$tmpresult" | grep -woP '"country"\s{0,}:\s{0,}"\K[^"]+')
+    result=$(echo "$tmpresult" | $grep -woP '"country"\s{0,}:\s{0,}"\K[^"]+')
     if [ "$result" == 'TW' ]; then
         echo -n -e "\r KKTV:\t\t\t\t\t${Font_Green}Yes${Font_Suffix}\n"
         return
@@ -1637,7 +1640,7 @@ function MediaUnlockTest_PeacockTV() {
     fi
 
     local urlEffective=$(echo "$tmpresult" | awk -F'_TAG_' '{print $2}')
-    local result=$(echo "$urlEffective" | grep -i 'unavailable')
+    local result=$(echo "$urlEffective" | $grep -i 'unavailable')
 
     if [ -n "$result" ]; then
         echo -n -e "\r Peacock TV:\t\t\t\t${Font_Red}No${Font_Suffix}\n"
@@ -1663,7 +1666,7 @@ function MediaUnlockTest_FOD() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '<FLAG\sTYPE="\K[^"]+')
+    local result=$(echo "$tmpresult" | $grep -woP '<FLAG\sTYPE="\K[^"]+')
     case "$result" in
         'true') echo -n -e "\r FOD(Fuji TV):\t\t\t\t${Font_Green}Yes${Font_Suffix}\n" ;;
         'false') echo -n -e "\r FOD(Fuji TV):\t\t\t\t${Font_Red}No${Font_Suffix}\n" ;;
@@ -1679,16 +1682,16 @@ function MediaUnlockTest_YouTube_Premium() {
         return
     fi
 
-    local isCN=$(echo "$tmpresult" | grep 'www.google.cn')
+    local isCN=$(echo "$tmpresult" | $grep 'www.google.cn')
 
     if [ -n "$isCN" ]; then
         echo -n -e "\r YouTube Premium:\t\t\t${Font_Red}No${Font_Suffix} ${Font_Green} (Region: CN)${Font_Suffix} \n"
         return
     fi
 
-    local isNotAvailable=$(echo "$tmpresult" | grep -i 'Premium is not available in your country')
-    local region=$(echo "$tmpresult" | grep -woP '"INNERTUBE_CONTEXT_GL"\s{0,}:\s{0,}"\K[^"]+')
-    local isAvailable=$(echo "$tmpresult" | grep -i 'ad-free')
+    local isNotAvailable=$(echo "$tmpresult" | $grep -i 'Premium is not available in your country')
+    local region=$(echo "$tmpresult" | $grep -woP '"INNERTUBE_CONTEXT_GL"\s{0,}:\s{0,}"\K[^"]+')
+    local isAvailable=$(echo "$tmpresult" | $grep -i 'ad-free')
 
     if [ -n "$isNotAvailable" ]; then
         echo -n -e "\r YouTube Premium:\t\t\t${Font_Red}No${Font_Suffix}\n"
@@ -1712,10 +1715,10 @@ function RegionTest_YouTubeCDN() {
         return
     fi
 
-    local iata=$(echo "$tmpresult" | grep '=>' | awk "NR==1" | awk '{print $3}' | cut -f2 -d'-' | cut -c 1-3 | tr a-z A-Z)
-    local isIDC=$(echo "$tmpresult" | grep 'router')
-    local isIataFound1=$(echo "$IATACODE" | grep -w "$iata")
-    local isIataFound2=$(echo "$IATACODE2" | grep -w "$iata")
+    local iata=$(echo "$tmpresult" | $grep '=>' | awk "NR==1" | awk '{print $3}' | cut -f2 -d'-' | cut -c 1-3 | tr a-z A-Z)
+    local isIDC=$(echo "$tmpresult" | $grep 'router')
+    local isIataFound1=$(echo "$IATACODE" | $grep -w "$iata")
+    local isIataFound2=$(echo "$IATACODE2" | $grep -w "$iata")
 
     if [ -z "$iata" ]; then
         echo -n -e "\r YouTube CDN:\t\t\t\t${Font_Red}Failed (Error: Location Unknown)${Font_Suffix}\n"
@@ -1726,10 +1729,10 @@ function RegionTest_YouTubeCDN() {
         return
     fi
     if [ -n "$isIataFound1" ]; then
-        local location=$(echo "$IATACODE" | grep -w "$iata" | awk -F'|' '{print $1}' | awk '{$1=$1; print}')
+        local location=$(echo "$IATACODE" | $grep -w "$iata" | awk -F'|' '{print $1}' | awk '{$1=$1; print}')
     fi
     if [ -z "$isIataFound1" ] && [ -n "$isIataFound2" ]; then
-        local location=$(echo "$IATACODE2" | grep -w "$iata" | awk -F',' '{print $2}' | awk '{$1=$1; print}' | tr A-Z a-z | sed 's/\b[a-z]/\U&/g')
+        local location=$(echo "$IATACODE2" | $grep -w "$iata" | awk -F',' '{print $2}' | awk '{$1=$1; print}' | tr A-Z a-z | sed 's/\b[a-z]/\U&/g')
     fi
 
     if [ -z "$isIDC" ]; then
@@ -1752,8 +1755,8 @@ function WebTest_GoogleSearchCAPTCHA() {
         return
     fi
 
-    local isBlocked=$(echo "$tmpresult" | grep -iE 'unusual traffic from|is blocked|unaddressed abuse')
-    local isOK=$(echo "$tmpresult" | grep -i 'curl')
+    local isBlocked=$(echo "$tmpresult" | $grep -iE 'unusual traffic from|is blocked|unaddressed abuse')
+    local isOK=$(echo "$tmpresult" | $grep -i 'curl')
 
     if [ -z "$isBlocked" ] && [ -z "$isOK" ]; then
         echo -n -e "\r Google Search CAPTCHA Free:\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -1780,7 +1783,7 @@ function MediaUnlockTest_BritBox() {
     fi
 
     local urlEffective=$(echo "$tmpresult" | awk -F'_TAG_' '{print $2}')
-    local result=$(echo "$urlEffective" | grep -E 'locationnotsupported|locationnotvalidated|britbox.co.uk')
+    local result=$(echo "$urlEffective" | $grep -E 'locationnotsupported|locationnotvalidated|britbox.co.uk')
 
     if [ -n "$result" ]; then
         echo -n -e "\r BritBox:\t\t\t\t${Font_Red}No${Font_Suffix}\n"
@@ -1806,8 +1809,8 @@ function MediaUnlockTest_PrimeVideo() {
         return
     fi
 
-    local isBlocked=$(echo "$tmpresult" | grep -i 'isServiceRestricted')
-    local region=$(echo "$tmpresult" | grep -woP '"currentTerritory":"\K[^"]+' | head -n 1)
+    local isBlocked=$(echo "$tmpresult" | $grep -i 'isServiceRestricted')
+    local region=$(echo "$tmpresult" | $grep -woP '"currentTerritory":"\K[^"]+' | head -n 1)
 
     if [ -z "$isBlocked" ] && [ -z "$region" ]; then
         echo -n -e "\r Amazon Prime Video:\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -1837,8 +1840,8 @@ function MediaUnlockTest_Radiko() {
         return
     fi
 
-    local isBlocked=$(echo "$tmpresult" | grep 'class="OUT"')
-    local isOK=$(echo "$tmpresult" | grep -i 'JAPAN')
+    local isBlocked=$(echo "$tmpresult" | $grep 'class="OUT"')
+    local isOK=$(echo "$tmpresult" | $grep -i 'JAPAN')
 
     if [ -z "$isBlocked" ] && [ -z "$isOK" ]; then
         echo -n -e "\r Radiko:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -1869,8 +1872,8 @@ function MediaUnlockTest_DMM() {
         return
     fi
 
-    local isBlocked=$(echo "$tmpresult" | grep 'This page is not available in your area')
-    local isOK=$(echo "$tmpresult" | grep '暗号資産')
+    local isBlocked=$(echo "$tmpresult" | $grep 'This page is not available in your area')
+    local isOK=$(echo "$tmpresult" | $grep '暗号資産')
 
 
     if [ -z "$isBlocked" ] && [ -z "$isOK" ]; then
@@ -1901,8 +1904,8 @@ function MediaUnlockTest_DMMTV() {
         return
     fi
 
-    local isBlocked=$(echo "$tmpresult" | grep 'FOREIGN')
-    local isOK=$(echo "$tmpresult" | grep 'UNAUTHORIZED')
+    local isBlocked=$(echo "$tmpresult" | $grep 'FOREIGN')
+    local isOK=$(echo "$tmpresult" | $grep 'UNAUTHORIZED')
 
     if [ -z "$isBlocked" ] && [ -z "$isOK" ]; then
         echo -n -e "\r DMM TV:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -1932,7 +1935,7 @@ function MediaUnlockTest_Catchplay() {
         return
     fi
 
-    local result=$(echo "$tmpresult"  | grep -woP '"code"\s{0,}:\s{0,}"\K[^"]+')
+    local result=$(echo "$tmpresult"  | $grep -woP '"code"\s{0,}:\s{0,}"\K[^"]+')
     if [ -z "$result" ]; then
         echo -n -e "\r CatchPlay+:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
         return
@@ -1947,7 +1950,7 @@ function MediaUnlockTest_Catchplay() {
 function MediaUnlockTest_HotStar() {
     local tmpresult=$(curl ${CURL_DEFAULT_OPTS} -sLi 'https://www.hotstar.com' -w '\n_TAG_%{http_code}_TAG_%{url_effective}_TAG_\n' --user-agent "${UA_BROWSER}")
 
-    local httpCode=$(echo "$tmpresult" | grep -o '_TAG_.*_TAG_' | awk -F'_TAG_' '{print $2}')
+    local httpCode=$(echo "$tmpresult" | $grep -o '_TAG_.*_TAG_' | awk -F'_TAG_' '{print $2}')
 
     if [ "$httpCode" == '000' ]; then
         echo -n -e "\r HotStar:\t\t\t\t${Font_Red}Failed (Network Connection)${Font_Suffix}\n"
@@ -1962,8 +1965,8 @@ function MediaUnlockTest_HotStar() {
         return
     fi
 
-    local urlEffective=$(echo "$tmpresult" | grep -o '_TAG_.*_TAG_' | awk -F'_TAG_' '{print $3}')
-    local region=$(echo "$tmpresult" | grep -woP 'geo=\K[A-Z]+' | head -n 1)
+    local urlEffective=$(echo "$tmpresult" | $grep -o '_TAG_.*_TAG_' | awk -F'_TAG_' '{print $3}')
+    local region=$(echo "$tmpresult" | $grep -woP 'geo=\K[A-Z]+' | head -n 1)
     local siteRegion=$(echo "$urlEffective" | sed 's@.*com/@@' | tr a-z A-Z)
 
     if [ -z "$region" ]; then
@@ -1995,8 +1998,8 @@ function MediaUnlockTest_LiTV() {
         return
     fi
 
-    local isOK=$(echo "$tmpresult" | grep 'AssetURLs')
-    local result=$(echo "$tmpresult" | grep -woP '"code"\s{0,}:\s{0,}\K[^"][0-9]{0,}')
+    local isOK=$(echo "$tmpresult" | $grep 'AssetURLs')
+    local result=$(echo "$tmpresult" | $grep -woP '"code"\s{0,}:\s{0,}\K[^"][0-9]{0,}')
 
     if [ -n "$isOK" ]; then
         echo -n -e "\r LiTV:\t\t\t\t\t${Font_Green}Yes${Font_Suffix}\n"
@@ -2023,10 +2026,10 @@ function MediaUnlockTest_FuboTV() {
         return
     fi
 
-    local noService=$(echo "$tmpresult" | grep -i 'NO_SERVICE_IN_COUNTRY')
-    local isAllowed=$(echo "$tmpresult" | grep -o '"network_allowed":true')
-    local isBlocked=$(echo "$tmpresult" | grep -o '"network_allowed":false')
-    local countryCode=$(echo "$tmpresult" | grep -oP '"country_code2":"\K[^"]+')
+    local noService=$(echo "$tmpresult" | $grep -i 'NO_SERVICE_IN_COUNTRY')
+    local isAllowed=$(echo "$tmpresult" | $grep -o '"network_allowed":true')
+    local isBlocked=$(echo "$tmpresult" | $grep -o '"network_allowed":false')
+    local countryCode=$(echo "$tmpresult" | $grep -oP '"country_code2":"\K[^"]+')
 
     if [ -n "$noService" ]; then
         echo -n -e "\r Fubo TV:\t\t\t\t${Font_Red}No${Font_Suffix}\n"
@@ -2067,15 +2070,15 @@ function MediaUnlockTest_Joyn() {
         return
     fi
 
-    local auth=$(echo "$tmpauth" | grep -woP '"access_token"\s{0,}:\s{0,}"\K[^"]+')
+    local auth=$(echo "$tmpauth" | $grep -woP '"access_token"\s{0,}:\s{0,}"\K[^"]+')
     local tmpresult=$(curl ${CURL_DEFAULT_OPTS} -s 'https://api.joyn.de/content/entitlement-token' -H "x-api-key: 36lp1t4wto5uu2i2nk57ywy9on1ns5yg" -H "content-type: application/json" -d '{"content_id":"daserste-de-hd","content_type":"LIVE"}' -H "authorization: Bearer ${auth}" --user-agent "${UA_BROWSER}")
     if [ -z "$tmpresult" ]; then
         echo -n -e "\r Joyn:\t\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
         return
     fi
 
-    local isOK=$(echo "$tmpresult" | grep -i 'entitlement_token')
-    local isBlocked=$(echo "$tmpresult" | grep -i 'ENT_AssetNotAvailableInCountry')
+    local isOK=$(echo "$tmpresult" | $grep -i 'entitlement_token')
+    local isBlocked=$(echo "$tmpresult" | $grep -i 'ENT_AssetNotAvailableInCountry')
 
     if [ -z "$isOK" ] && [ -z "$isBlocked" ]; then
         echo -n -e "\r Joyn:\t\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -2105,7 +2108,7 @@ function MediaUnlockTest_SpotvNow() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"error_subcode"\s{0,}:\s{0,}"\K[^"]+')
+    local result=$(echo "$tmpresult" | $grep -woP '"error_subcode"\s{0,}:\s{0,}"\K[^"]+')
 
     case "$result" in
         'CLIENT_GEO') echo -n -e "\r SPOTV NOW:\t\t\t\t${Font_Red}No${Font_Suffix}\n" ;;
@@ -2126,7 +2129,7 @@ function MediaUnlockTest_SKY_DE() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"error_subcode"\s{0,}:\s{0,}"\K[^"]+')
+    local result=$(echo "$tmpresult" | $grep -woP '"error_subcode"\s{0,}:\s{0,}"\K[^"]+')
 
     case "$result" in
         'CLIENT_GEO') echo -n -e "\r SKY DE:\t\t\t\t${Font_Red}No${Font_Suffix}\n" ;;
@@ -2163,13 +2166,13 @@ function MediaUnlockTest_HBOGO_ASIA() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"territory"\s{0,}:\s{0,}"\K[^"]+')
+    local result=$(echo "$tmpresult" | $grep -woP '"territory"\s{0,}:\s{0,}"\K[^"]+')
     if [ -z "$result" ]; then
         echo -n -e "\r HBO GO Asia:\t\t\t\t${Font_Red}No${Font_Suffix}\n"
         return
     fi
 
-    local region=$(echo "$tmpresult" | grep -woP '"country"\s{0,}:\s{0,}"\K[^"]+')
+    local region=$(echo "$tmpresult" | $grep -woP '"country"\s{0,}:\s{0,}"\K[^"]+')
     if [ -n "$region" ]; then
         echo -n -e "\r HBO GO Asia:\t\t\t\t${Font_Green}Yes (Region: ${region})${Font_Suffix}\n"
         return
@@ -2190,13 +2193,13 @@ function MediaUnlockTest_EPIX() {
         return
     fi
 
-    local is403=$(echo "$tmpToken" | grep -i '403 ERROR')
+    local is403=$(echo "$tmpToken" | $grep -i '403 ERROR')
     if [ -n "$is403" ]; then
         echo -n -e "\r MGM+:\t\t\t\t\t${Font_Red}No${Font_Suffix}\n"
         return
     fi
 
-    local epixToken=$(echo "$tmpToken" | grep -woP '"session_token"\s{0,}:\s{0,}"\K[^"]+')
+    local epixToken=$(echo "$tmpToken" | $grep -woP '"session_token"\s{0,}:\s{0,}"\K[^"]+')
     if [ -z "$epixToken" ]; then
         echo -n -e "\r MGM+:\t\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
         return
@@ -2204,8 +2207,8 @@ function MediaUnlockTest_EPIX() {
 
     local tmpresult=$(curl ${CURL_DEFAULT_OPTS} -s 'https://api.epix.com/graphql' -X POST -H 'host: api.epix.com' -H "sec-ch-ua: ${UA_SEC_CH_UA}" -H 'traceparent: 00-0000000000000000603047c112148412-32d64f8c890631ef-01' -H 'sec-ch-ua-mobile: ?0' -H 'x-datadog-origin: rum' -H 'x-datadog-sampling-priority: 1' -H 'accept: application/json' -H "x-session-token: ${epixToken}" -H 'x-datadog-trace-id: 6931118721080787986' -H 'x-datadog-parent-id: 3663202811925377519' -H 'sec-ch-ua-platform: "Windows"' -H 'origin: https://www.mgmplus.com' -H 'sec-fetch-site: cross-site' -H 'sec-fetch-mode: cors' -H 'sec-fetch-dest: empty' -H 'referer: https://www.mgmplus.com/' -H 'accept-language: en-US,en;q=0.9' -H 'content-type: application/json' -d '{"operationName":"PlayFlow","variables":{"id":"c2VyaWVzOzEwMTc=","supportedActions":["open_url","show_notice","start_billing","play_content","log_in","noop","confirm_provider","unlinked_provider"],"streamTypes":[{"encryptionScheme":"CBCS","packagingSystem":"DASH"},{"encryptionScheme":"CENC","packagingSystem":"DASH"},{"encryptionScheme":"NONE","packagingSystem":"HLS"},{"encryptionScheme":"SAMPLE_AES","packagingSystem":"HLS"}]},"query":"fragment ShowNotice on ShowNotice {\n  type\n  actions {\n    continuationContext\n    text\n    __typename\n  }\n  description\n  title\n  __typename\n}\n\nfragment OpenUrl on OpenUrl {\n  type\n  url\n  __typename\n}\n\nfragment Content on Content {\n  title\n  __typename\n}\n\nfragment Movie on Movie {\n  id\n  shortName\n  __typename\n}\n\nfragment Episode on Episode {\n  id\n  series {\n    shortName\n    __typename\n  }\n  seasonNumber\n  number\n  __typename\n}\n\nfragment Preroll on Preroll {\n  id\n  __typename\n}\n\nfragment ContentUnion on ContentUnion {\n  ...Content\n  ...Movie\n  ...Episode\n  ...Preroll\n  __typename\n}\n\nfragment PlayContent on PlayContent {\n  type\n  continuationContext\n  heartbeatToken\n  currentItem {\n    content {\n      ...ContentUnion\n      __typename\n    }\n    __typename\n  }\n  nextItem {\n    content {\n      ...ContentUnion\n      __typename\n    }\n    showNotice {\n      ...ShowNotice\n      __typename\n    }\n    showNoticeAt\n    __typename\n  }\n  amazonPlaybackData {\n    pid\n    playbackToken\n    materialType\n    __typename\n  }\n  playheadPosition\n  vizbeeStreamInfo {\n    customStreamInfo\n    __typename\n  }\n  closedCaptions {\n    ttml {\n      location\n      __typename\n    }\n    vtt {\n      location\n      __typename\n    }\n    xml {\n      location\n      __typename\n    }\n    __typename\n  }\n  hints {\n    duration\n    seekAllowed\n    trackingEnabled\n    trackingId\n    __typename\n  }\n  streams(types: $streamTypes) {\n    playlistUrl\n    closedCaptionsEmbedded\n    packagingSystem\n    encryptionScheme\n    videoQuality {\n      height\n      width\n      __typename\n    }\n    widevine {\n      authenticationToken\n      licenseServerUrl\n      __typename\n    }\n    playready {\n      authenticationToken\n      licenseServerUrl\n      __typename\n    }\n    fairplay {\n      authenticationToken\n      certificateUrl\n      licenseServerUrl\n      __typename\n    }\n    __typename\n  }\n  __typename\n}\n\nfragment StartBilling on StartBilling {\n  type\n  __typename\n}\n\nfragment LogIn on LogIn {\n  type\n  __typename\n}\n\nfragment Noop on Noop {\n  type\n  __typename\n}\n\nfragment PreviewContent on PreviewContent {\n  type\n  title\n  description\n  stream {\n    sources {\n      hls {\n        location\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n  __typename\n}\n\nfragment ConfirmProvider on ConfirmProvider {\n  type\n  __typename\n}\n\nfragment UnlinkedProvider on UnlinkedProvider {\n  type\n  __typename\n}\n\nquery PlayFlow($id: String!, $supportedActions: [PlayFlowActionEnum!]!, $context: String, $behavior: BehaviorEnum = DEFAULT, $streamTypes: [StreamDefinition!]) {\n  playFlow(\n    id: $id\n    supportedActions: $supportedActions\n    context: $context\n    behavior: $behavior\n  ) {\n    ...ShowNotice\n    ...OpenUrl\n    ...PlayContent\n    ...StartBilling\n    ...LogIn\n    ...Noop\n    ...PreviewContent\n    ...ConfirmProvider\n    ...UnlinkedProvider\n    __typename\n  }\n}"}' --user-agent "${UA_BROWSER}")
 
-    local isBlocked=$(echo "$tmpresult" | grep -i 'MGM+ is only available in the United States')
-    local isOK=$(echo "$tmpresult" | grep -i 'StartBilling')
+    local isBlocked=$(echo "$tmpresult" | $grep -i 'MGM+ is only available in the United States')
+    local isOK=$(echo "$tmpresult" | $grep -i 'StartBilling')
 
     if [ -z "$isBlocked" ] && [ -z "$isOK" ]; then
         echo -n -e "\r MGM+:\t\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -2235,8 +2238,8 @@ function MediaUnlockTest_NLZIET() {
         return
     fi
 
-    local isBlocked=$(echo "$tmpresult" | grep -i 'CountryNotAllowed')
-    local isOK=$(echo "$tmpresult" | grep -i 'streamSessionId')
+    local isBlocked=$(echo "$tmpresult" | $grep -i 'CountryNotAllowed')
+    local isOK=$(echo "$tmpresult" | $grep -i 'streamSessionId')
 
     if [ -z "$isBlocked" ] && [ -z "$isOK" ]; then
         echo -n -e "\r NLZIET:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -2261,7 +2264,7 @@ function MediaUnlockTest_videoland() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"isOnboardingGeoBlocked"\s{0,}:\s{0,}\K(false|true)')
+    local result=$(echo "$tmpresult" | $grep -woP '"isOnboardingGeoBlocked"\s{0,}:\s{0,}\K(false|true)')
     case "$result" in
         'false') echo -n -e "\r videoland:\t\t\t\t${Font_Green}Yes${Font_Suffix}\n" ;;
         'true') echo -n -e "\r videoland:\t\t\t\t${Font_Red}No${Font_Suffix}\n" ;;
@@ -2277,7 +2280,7 @@ function MediaUnlockTest_NPO_Start_Plus() {
         return
     fi
 
-    local token=$(echo "$tmpresult" | grep -woP '"token"\s{0,}:\s{0,}"\K[^"]+')
+    local token=$(echo "$tmpresult" | $grep -woP '"token"\s{0,}:\s{0,}"\K[^"]+')
     local result=$(curl ${CURL_DEFAULT_OPTS} -s 'https://prod.npoplayer.nl/stream-link' -w %{http_code} -o /dev/null -H 'accept: */*' -H "authorization: ${token}" -H 'content-type: application/json' -H 'origin: https://npo.nl' -H 'referer: https://npo.nl/' -H "sec-ch-ua: ${UA_SEC_CH_UA}" -H 'sec-ch-ua-mobile: ?0' -H 'sec-ch-ua-platform: "Windows"' -H 'sec-fetch-dest: empty' -H 'sec-fetch-mode: cors' -H 'sec-fetch-site: cross-site' --data-raw '{"profileName":"dash","drmType":"playready","referrerUrl":"https://npo.nl/start/live?channel=NPO1"}' -H 'accept-language: en-US,en;q=0.9' --user-agent "${UA_BROWSER}")
 
     case "$result" in
@@ -2303,19 +2306,19 @@ function MediaUnlockTest_RakutenTV() {
         return
     fi
 
-    local isBlocked=$(echo "$tmpresult" | grep -iE 'VPN|forbidden|is not available')
+    local isBlocked=$(echo "$tmpresult" | $grep -iE 'VPN|forbidden|is not available')
     if [ -n "$isBlocked" ]; then
         echo -n -e "\r Rakuten TV:\t\t\t\t${Font_Red}No${Font_Suffix}\n"
         return
     fi
 
-    local region=$(echo "$tmpresult" | grep -woP '"iso3166_code"\s{0,}:\s{0,}"\K[^"]+')
+    local region=$(echo "$tmpresult" | $grep -woP '"iso3166_code"\s{0,}:\s{0,}"\K[^"]+')
     if [ -z "$region" ]; then
         echo -n -e "\r Rakuten TV:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
         return
     fi
 
-    local isOK=$(echo "$tmpresult" | grep -i 'streaming_drm_types')
+    local isOK=$(echo "$tmpresult" | $grep -i 'streaming_drm_types')
     if [ -n "$isOK" ]; then
         echo -n -e "\r Rakuten TV:\t\t\t\t${Font_Green}Yes (Region: ${region})${Font_Suffix}\n"
         return
@@ -2357,9 +2360,9 @@ function MediaUnlockTest_Starz() {
         return
     fi
 
-    local isAllowedAccess=$(echo "$tmpresult" | grep -woP '"isAllowedAccess"\s{0,}:\s{0,}\K(false|true)')
-    local isAllowedCountry=$(echo "$tmpresult" | grep -woP '"isAllowedCountry"\s{0,}:\s{0,}\K(false|true)')
-    local isKnownProxy=$(echo "$tmpresult" | grep -woP '"isKnownProxy"\s{0,}:\s{0,}\K(false|true)')
+    local isAllowedAccess=$(echo "$tmpresult" | $grep -woP '"isAllowedAccess"\s{0,}:\s{0,}\K(false|true)')
+    local isAllowedCountry=$(echo "$tmpresult" | $grep -woP '"isAllowedCountry"\s{0,}:\s{0,}\K(false|true)')
+    local isKnownProxy=$(echo "$tmpresult" | $grep -woP '"isKnownProxy"\s{0,}:\s{0,}\K(false|true)')
 
     if [ -z "$isAllowedAccess" ] || [ -z "$isAllowedCountry" ] || [ -z "$isKnownProxy" ]; then
         echo -n -e "\r Starz:\t\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -2395,7 +2398,7 @@ function MediaUnlockTest_CanalPlus() {
     fi
 
     local urlEffective=$(echo "$tmpresult" | awk -F'_TAG_' '{print $2}')
-    local result=$(echo "$urlEffective" | grep -i 'other-country-blocking')
+    local result=$(echo "$urlEffective" | $grep -i 'other-country-blocking')
     if [ -n "$result" ]; then
         echo -n -e "\r Canal+:\t\t\t\t${Font_Red}No${Font_Suffix}\n"
         return
@@ -2422,7 +2425,7 @@ function MediaUnlockTest_Sky_CH() {
     fi
 
     local urlEffective=$(echo "$tmpresult" | awk -F'_TAG_' '{print $2}')
-    local result=$(echo "$urlEffective" | grep -i 'out-of-country')
+    local result=$(echo "$urlEffective" | $grep -i 'out-of-country')
     if [ -n "$result" ]; then
         echo -n -e "\r SKY CH:\t\t\t\t${Font_Red}No${Font_Suffix}\n"
         return
@@ -2448,7 +2451,7 @@ function MediaUnlockTest_CBCGem() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"country"\s{0,}:\s{0,}"\K[^"]+')
+    local result=$(echo "$tmpresult" | $grep -woP '"country"\s{0,}:\s{0,}"\K[^"]+')
     if [ -z "${result}" ]; then
         echo -n -e "\r CBC Gem:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
         return
@@ -2474,8 +2477,8 @@ function MediaUnlockTest_AcornTV() {
         return
     fi
 
-    local isBlocked=$(echo "$tmpresult" | grep -iE 'not yet available in your|unavailable in your')
-    local isOK=$(echo "$tmpresult" | grep -i 'signup.acorn.tv')
+    local isBlocked=$(echo "$tmpresult" | $grep -iE 'not yet available in your|unavailable in your')
+    local isOK=$(echo "$tmpresult" | $grep -i 'signup.acorn.tv')
 
     if [ -z "$isBlocked" ] && [ -z "$isOK" ]; then
         echo -n -e "\r Acorn TV:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -2505,8 +2508,8 @@ function MediaUnlockTest_Crave() {
         return
     fi
 
-    local isOK=$(echo "$tmpresult" | grep -i 'video.9c9media.com')
-    local isBlocked=$(echo "$tmpresult" | grep -i 'Geo Constraint Restrictions')
+    local isOK=$(echo "$tmpresult" | $grep -i 'video.9c9media.com')
+    local isBlocked=$(echo "$tmpresult" | $grep -i 'Geo Constraint Restrictions')
 
     if [ -z "$isOK" ] && [ -z "$isBlocked" ]; then
         echo -n -e "\r Crave:\t\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -2538,7 +2541,7 @@ function MediaUnlockTest_Amediateka() {
     fi
 
     local urlEffective=$(echo "$tmpresult" | awk -F'_TAG_' '{print $2}')
-    local result=$(echo "$urlEffective" | grep -i 'unavailable')
+    local result=$(echo "$urlEffective" | $grep -i 'unavailable')
     if [ -n "$result" ]; then
         echo -n -e "\r Amediateka:\t\t\t\t${Font_Red}No${Font_Suffix}\n"
         return
@@ -2567,7 +2570,7 @@ function MediaUnlockTest_MegogoTV() {
         return
     fi
 
-    local vpnDetected=$(echo "$tmpresult" | grep -i 'VPN')
+    local vpnDetected=$(echo "$tmpresult" | $grep -i 'VPN')
     if [ -n "$vpnDetected" ]; then
         echo -n -e "\r Abema.TV:\t\t\t\t${Font_Yellow}Yes (VPN Detected)${Font_Suffix}\n"
         return
@@ -2588,8 +2591,8 @@ function MediaUnlockTest_RaiPlay() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '<geoprotection>\K[^<]+')
-    local isBlocked=$(echo "$tmpresult" | grep -i 'video_no_available')
+    local result=$(echo "$tmpresult" | $grep -woP '<geoprotection>\K[^<]+')
+    local isBlocked=$(echo "$tmpresult" | $grep -i 'video_no_available')
 
     if [ -z "$result" ]; then
         echo -n -e "\r Rai Play:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -2619,7 +2622,7 @@ function MediaUnlockTest_TVBAnywhere() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"allow_in_this_country"\s{0,}:\s{0,}\K(false|true)')
+    local result=$(echo "$tmpresult" | $grep -woP '"allow_in_this_country"\s{0,}:\s{0,}\K(false|true)')
     if [ -z "$result" ]; then
         echo -n -e "\r TVBAnywhere+:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
         return
@@ -2671,7 +2674,7 @@ function MediaUnlockTest_NBATV() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -i 'Service is not available in your region')
+    local result=$(echo "$tmpresult" | $grep -i 'Service is not available in your region')
 
     if [ -z "$result" ]; then
         echo -n -e "\r NBA TV:\t\t\t\t${Font_Green}Yes${Font_Suffix}\n"
@@ -2694,7 +2697,7 @@ function MediaUnlockTest_Directv() {
 
 function RegionTest_NetflixCDN() {
     local tmpresult=$(curl ${CURL_DEFAULT_OPTS} -s 'https://api.fast.com/netflix/speedtest/v2?https=true&token=YXNkZmFzZGxmbnNkYWZoYXNkZmhrYWxm&urlCount=1' -w '_TAG_%{http_code}' --user-agent "${UA_BROWSER}")
-    local httpCode=$(echo "$tmpresult" | grep '_TAG_' | awk -F'_TAG_' '{print $2}')
+    local httpCode=$(echo "$tmpresult" | $grep '_TAG_' | awk -F'_TAG_' '{print $2}')
     local respContent=$(echo "$tmpresult" | awk -F'_TAG_' '{print $1}')
     if [ "$httpCode" == '000' ]; then
         echo -n -e "\r Netflix Preferred CDN:\t\t\t${Font_Red}Failed (Network Connection)${Font_Suffix}\n"
@@ -2705,7 +2708,7 @@ function RegionTest_NetflixCDN() {
         return
     fi
 
-    local cdnDomain=$(echo "$respContent" | grep -woP '"url":"\K[^"]+' | awk -F'[/:]' '{print $4}')
+    local cdnDomain=$(echo "$respContent" | $grep -woP '"url":"\K[^"]+' | awk -F'[/:]' '{print $4}')
     if [ -z "$cdnDomain" ]; then
         echo -n -e "\r Netflix Preferred CDN:\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
         return
@@ -2729,7 +2732,7 @@ function RegionTest_NetflixCDN() {
             return
         fi
 
-        local cdnISP=$(echo "$tmpresult1" | grep -woP '"isp"\s{0,}:\s{0,}"\K[^"]+')
+        local cdnISP=$(echo "$tmpresult1" | $grep -woP '"isp"\s{0,}:\s{0,}"\K[^"]+')
         if [ -z "$cdnISP" ]; then
             echo -n -e "\r Netflix Preferred CDN:\t\t\t${Font_Red}Failed (Error: No ISP Info Found)${Font_Suffix}\n"
             return
@@ -2741,14 +2744,14 @@ function RegionTest_NetflixCDN() {
     local iata=$(echo "$cdnDomain" | cut -f3 -d'-' | sed 's/.\{3\}$//' | tr a-z A-Z)
 
     # local IATACODE2=$(curl ${CURL_DEFAULT_OPTS} -s "https://raw.githubusercontent.com/lmc999/RegionRestrictionCheck/main/reference/IATACODE2.txt" 2>&1)
-    local isIataFound1=$(echo "$IATACODE" | grep -w "$iata")
-    local isIataFound2=$(echo "$IATACODE2" | grep -w "$iata")
+    local isIataFound1=$(echo "$IATACODE" | $grep -w "$iata")
+    local isIataFound2=$(echo "$IATACODE2" | $grep -w "$iata")
 
     if [ -n "$isIataFound1" ]; then
-        local location=$(echo "$IATACODE" | grep -w "$iata" | awk -F'|' '{print $1}' | awk '{$1=$1; print}')
+        local location=$(echo "$IATACODE" | $grep -w "$iata" | awk -F'|' '{print $1}' | awk '{$1=$1; print}')
     fi
     if [ -z "$isIataFound1" ] && [ -n "$isIataFound2" ]; then
-        local location=$(echo "$IATACODE2" | grep -w "$iata" | awk -F',' '{print $2}' | awk '{$1=$1; print}' | tr A-Z a-z | sed 's/\b[a-z]/\U&/g')
+        local location=$(echo "$IATACODE2" | $grep -w "$iata" | awk -F',' '{print $2}' | awk '{$1=$1; print}' | tr A-Z a-z | sed 's/\b[a-z]/\U&/g')
     fi
 
     if [ -z "$location" ]; then
@@ -2779,7 +2782,7 @@ function MediaUnlockTest_SkyGo() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -i "You don't have permission to access")
+    local result=$(echo "$tmpresult" | $grep -i "You don't have permission to access")
     if [ -z "$result" ]; then
         echo -n -e "\r Sky Go:\t\t\t\t${Font_Green}Yes${Font_Suffix}\n"
         return
@@ -2802,7 +2805,7 @@ function MediaUnlockTest_DirecTVGO() {
     fi
 
     local urlEffective=$(echo "$tmpresult" | awk -F'_TAG_' '{print $2}')
-    local isForbidden=$(echo "$urlEffective" | grep 'proximamente')
+    local isForbidden=$(echo "$urlEffective" | $grep 'proximamente')
     local region=$(echo "$urlEffective" | cut -f4 -d'/' | tr a-z A-Z)
 
     if [ -n "$isForbidden" ]; then
@@ -2850,8 +2853,8 @@ function MediaUnlockTest_DiscoveryPlus() {
         return
     fi
 
-    local baseApiUrl=$(echo "$tmpresult" | grep -woP '"baseApiUrl"\s{0,}:\s{0,}"\K[^"]+')
-    local realm=$(echo "$tmpresult" | grep -woP '"realm"\s{0,}:\s{0,}"\K[^"]+')
+    local baseApiUrl=$(echo "$tmpresult" | $grep -woP '"baseApiUrl"\s{0,}:\s{0,}"\K[^"]+')
+    local realm=$(echo "$tmpresult" | $grep -woP '"realm"\s{0,}:\s{0,}"\K[^"]+')
 
     if [ -z "$baseApiUrl" ] || [ -z "$realm" ]; then
         echo -n -e "\r Discovery+:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -2871,7 +2874,7 @@ function MediaUnlockTest_DiscoveryPlus() {
         return
     fi
 
-    local token=$(echo "$tmpresult1" | grep -woP '"token"\s{0,}:\s{0,}"\K[^"]+')
+    local token=$(echo "$tmpresult1" | $grep -woP '"token"\s{0,}:\s{0,}"\K[^"]+')
     if [ -z "$token" ]; then
         echo -n -e "\r Discovery+:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR 1)${Font_Suffix}\n"
         return
@@ -2883,9 +2886,9 @@ function MediaUnlockTest_DiscoveryPlus() {
         return
     fi
 
-    local isBlocked=$(echo "$tmpresult2" | grep -iE 'is unavailable in your|not yet available')
-    local isOK=$(echo "$tmpresult2" | grep -i 'relationships')
-    local region=$(echo "$tmpresult2" | grep -woP '"mainTerritoryCode"\s{0,}:\s{0,}"\K[^"]+' | tr a-z A-Z)
+    local isBlocked=$(echo "$tmpresult2" | $grep -iE 'is unavailable in your|not yet available')
+    local isOK=$(echo "$tmpresult2" | $grep -i 'relationships')
+    local region=$(echo "$tmpresult2" | $grep -woP '"mainTerritoryCode"\s{0,}:\s{0,}"\K[^"]+' | tr a-z A-Z)
 
     if [ -z "$isBlocked" ] && [ -z "$isOK" ]; then
         echo -n -e "\r Discovery+:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR 2)${Font_Suffix}\n"
@@ -2913,8 +2916,8 @@ function MediaUnlockTest_ESPNPlus() {
         return
     fi
 
-    local isBlocked=$(echo "$tokenContent" | grep 'forbidden-location')
-    local is403=$(echo "$tokenContent" | grep '403 ERROR')
+    local isBlocked=$(echo "$tokenContent" | $grep 'forbidden-location')
+    local is403=$(echo "$tokenContent" | $grep '403 ERROR')
 
     if [ -n "$isBlocked" ] || [ -n "$is403" ]; then
         echo -n -e "\r ESPN+:${Font_SkyBlue}[Sponsored by Jam]${Font_Suffix}\t\t${Font_Red}No${Font_Suffix}\n"
@@ -2922,7 +2925,7 @@ function MediaUnlockTest_ESPNPlus() {
     fi
 
     local fakeContent=$(echo "$MEDIA_COOKIE" | sed -n '10p')
-    local refreshToken=$(echo "$tokenContent" | grep -woP '"refresh_token"\s{0,}:\s{0,}"\K[^"]+')
+    local refreshToken=$(echo "$tokenContent" | $grep -woP '"refresh_token"\s{0,}:\s{0,}"\K[^"]+')
     if [ -z "$refreshToken" ]; then
         echo -n -e "\r ESPN+:${Font_SkyBlue}[Sponsored by Jam]${Font_Suffix}\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
         return
@@ -2935,8 +2938,8 @@ function MediaUnlockTest_ESPNPlus() {
         return
     fi
 
-    local region=$(echo "$tmpresult" | grep -woP '"countryCode"\s{0,}:\s{0,}"\K[^"]+')
-    local inSupportedLocation=$(echo "$tmpresult" | grep -woP '"inSupportedLocation"\s{0,}:\s{0,}\K(false|true)')
+    local region=$(echo "$tmpresult" | $grep -woP '"countryCode"\s{0,}:\s{0,}"\K[^"]+')
+    local inSupportedLocation=$(echo "$tmpresult" | $grep -woP '"inSupportedLocation"\s{0,}:\s{0,}\K(false|true)')
 
     if [ -z "$region" ] || [ -z "$inSupportedLocation" ]; then
         echo -n -e "\r ESPN+:${Font_SkyBlue}[Sponsored by Jam]${Font_Suffix}\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -2958,7 +2961,7 @@ function MediaUnlockTest_Stan() {
     fi
 
     local tmpresult=$(curl ${CURL_DEFAULT_OPTS} -s 'https://api.stan.com.au/login/v1/sessions/web/account' -X POST -w '_TAG_%{http_code}' --user-agent "${UA_BROWSER}")
-    local httpCode=$(echo "$tmpresult" | grep '_TAG_' | awk -F'_TAG_' '{print $2}')
+    local httpCode=$(echo "$tmpresult" | $grep '_TAG_' | awk -F'_TAG_' '{print $2}')
     local respContent=$(echo "$tmpresult" | awk -F'_TAG_' '{print $1}')
     if [ "$httpCode" == '000' ]; then
         echo -n -e "\r Stan:\t\t\t\t\t${Font_Red}Failed (Network Connection)${Font_Suffix}\n"
@@ -2978,7 +2981,7 @@ function MediaUnlockTest_Stan() {
         return
     fi
 
-    local result=$(echo "$respContent" | grep -i 'VPNDetected')
+    local result=$(echo "$respContent" | $grep -i 'VPNDetected')
     if [ -z "$result" ]; then
         echo -n -e "\r Stan:\t\t\t\t\t${Font_Green}Yes${Font_Suffix}\n"
         return
@@ -3012,7 +3015,7 @@ function MediaUnlockTest_Docplay() {
     fi
 
     local urlEffective=$(echo "$tmpresult" | awk -F'_TAG_' '{print $2}')
-    local isBlocked=$(echo "$urlEffective" | grep -i 'geoblocked')
+    local isBlocked=$(echo "$urlEffective" | $grep -i 'geoblocked')
 
     if [ -n "$isBlocked" ]; then
         echo -n -e "\r Docplay:\t\t\t\t${Font_Red}No${Font_Suffix}\n"
@@ -3062,7 +3065,7 @@ function MediaUnlockTest_NeonTV() {
     local neonContent=$(echo "$MEDIA_COOKIE" | sed -n '13p')
     local tmpresult=$(curl ${CURL_DEFAULT_OPTS} -s 'https://api.neontv.co.nz/api/client/gql?' -X POST -H "content-type: application/json" -H "$neonHeader" -d "$neonContent" -w '_TAG_%{http_code}' --user-agent "${UA_BROWSER}")
 
-    local httpCode=$(echo "$tmpresult" | grep '_TAG_' | awk -F'_TAG_' '{print $2}')
+    local httpCode=$(echo "$tmpresult" | $grep '_TAG_' | awk -F'_TAG_' '{print $2}')
     local respContent=$(echo "$tmpresult" | awk -F'_TAG_' '{print $1}')
     if [ "$httpCode" == '000' ]; then
         echo -n -e "\r Neon TV:\t\t\t\t${Font_Red}Failed (Network Connection)${Font_Suffix}\n"
@@ -3078,7 +3081,7 @@ function MediaUnlockTest_NeonTV() {
         return
     fi
 
-    local result=$(echo "$respContent" | grep -i 'RESTRICTED_GEOLOCATION')
+    local result=$(echo "$respContent" | $grep -i 'RESTRICTED_GEOLOCATION')
     if [ -z "$result" ]; then
         echo -n -e "\r Neon TV:\t\t\t\t${Font_Green}Yes${Font_Suffix}\n"
         return
@@ -3132,7 +3135,7 @@ function MediaUnlockTest_MaoriTV() {
     fi
 
     # 找出 index-*.js
-    local indexJsPath=$(echo "$tmpresult" | grep -woP 'src="\K/assets/index-[a-z0-9]{8}[^"]+')
+    local indexJsPath=$(echo "$tmpresult" | $grep -woP 'src="\K/assets/index-[a-z0-9]{8}[^"]+')
     if [ -z "$indexJsPath" ]; then
         echo -n -e "\r Maori TV:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
         return
@@ -3144,8 +3147,8 @@ function MediaUnlockTest_MaoriTV() {
         return
     fi
     # 取得 brightcove 播放器链接
-    local playerJsUrl=$(echo "$tmpresult2" | grep -woP 'players.brightcove.net/[0-9]{13}/\w{9}_default/index.min.js')
-    local accountId=$(echo "$playerJsUrl" | grep -woP 'players.brightcove.net/\K[0-9]{13}')
+    local playerJsUrl=$(echo "$tmpresult2" | $grep -woP 'players.brightcove.net/[0-9]{13}/\w{9}_default/index.min.js')
+    local accountId=$(echo "$playerJsUrl" | $grep -woP 'players.brightcove.net/\K[0-9]{13}')
     if [ -z "$playerJsUrl" ]; then
         echo -n -e "\r Maori TV:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
         return
@@ -3159,7 +3162,7 @@ function MediaUnlockTest_MaoriTV() {
     fi
 
     # 取 policy_key
-    local policyKey=$(echo "$tmpresult3" | grep -woP 'policyKey\s{0,}:\s{0,}"\KBCpk[^"]+')
+    local policyKey=$(echo "$tmpresult3" | $grep -woP 'policyKey\s{0,}:\s{0,}"\KBCpk[^"]+')
 
     # 由于频道 ID 换的不是特别勤，直接固定，少几个请求
     # 该值从该 API 获取：https://api.one.accedo.tv/content/entries?typeAlias=live-channels
@@ -3171,7 +3174,7 @@ function MediaUnlockTest_MaoriTV() {
         return
     fi
 
-    local result=$(echo "$tmpresult4" | grep -woP '"error_subcode"\s{0,}:\s{0,}"\K[^"]+')
+    local result=$(echo "$tmpresult4" | $grep -woP '"error_subcode"\s{0,}:\s{0,}"\K[^"]+')
 
     case "$result" in
         'CLIENT_GEO') echo -n -e "\r Maori TV:\t\t\t\t${Font_Red}No${Font_Suffix}\n" ;;
@@ -3193,7 +3196,7 @@ function MediaUnlockTest_SBSonDemand() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"country_code"\s{0,}:\s{0,}"\K[^"]+')
+    local result=$(echo "$tmpresult" | $grep -woP '"country_code"\s{0,}:\s{0,}"\K[^"]+')
     if [ -z "$result" ]; then
         echo -n -e "\r SBS on Demand:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
         return
@@ -3219,8 +3222,8 @@ function MediaUnlockTest_ABCiView() {
         return
     fi
 
-    local isBlocked=$(echo "$tmpresult" | grep -i 'unavailable outside Australia')
-    local isOK=$(echo "$tmpresult" | grep -woP '"playable"\s{0,}:\s{0,}\K(false|true)')
+    local isBlocked=$(echo "$tmpresult" | $grep -i 'unavailable outside Australia')
+    local isOK=$(echo "$tmpresult" | $grep -woP '"playable"\s{0,}:\s{0,}\K(false|true)')
 
     if [ -z "$isBlocked" ] && [ -z "$isOK" ]; then
         echo -n -e "\r ABC iView:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -3247,8 +3250,8 @@ function MediaUnlockTest_Channel9() {
         return
     fi
 
-    local isBlocked=$(echo "$tmpresult" | grep -i 'Geoblock')
-    local isOK=$(echo "$tmpresult" | grep -i 'Log in to')
+    local isBlocked=$(echo "$tmpresult" | $grep -i 'Geoblock')
+    local isOK=$(echo "$tmpresult" | $grep -i 'Log in to')
 
     if [ -z "$isBlocked" ] && [ -z "$isOK" ]; then
         echo -n -e "\r Channel 9:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -3273,8 +3276,8 @@ function MediaUnlockTest_Telasa() {
         return
     fi
 
-    local isForbidden=$(echo "$tmpresult" | grep -i 'IPLocationNotAllowed')
-    local isAllowed=$(echo "$tmpresult" | grep -woP '"type"\s{0,}:\s{0,}"\K[^"]+')
+    local isForbidden=$(echo "$tmpresult" | $grep -i 'IPLocationNotAllowed')
+    local isAllowed=$(echo "$tmpresult" | $grep -woP '"type"\s{0,}:\s{0,}"\K[^"]+')
 
     if [ -z "$isAllowed" ] && [ -z "$isForbidden" ]; then
         echo -n -e "\r Telasa:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -3304,7 +3307,7 @@ function MediaUnlockTest_SetantaSports() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"outsideAllowedTerritories"\s{0,}:\s{0,}\K(false|true)')
+    local result=$(echo "$tmpresult" | $grep -woP '"outsideAllowedTerritories"\s{0,}:\s{0,}\K(false|true)')
     if [ -z "$result" ]; then
         echo -n -e "\r Setanta Sports:\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
         return
@@ -3334,7 +3337,7 @@ function MediaUnlockTest_MolaTV() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"isAllowed"\s{0,}:\s{0,}\K(false|true)')
+    local result=$(echo "$tmpresult" | $grep -woP '"isAllowed"\s{0,}:\s{0,}\K(false|true)')
     if [ -z "$result" ]; then
         echo -n -e "\r Mola TV:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
         return
@@ -3382,7 +3385,7 @@ function MediaUnlockTest_EurosportRO() {
         return
     fi
 
-    local token=$(echo "$tmpresult" | grep -woP '"token"\s{0,}:\s{0,}"\K[^"]+')
+    local token=$(echo "$tmpresult" | $grep -woP '"token"\s{0,}:\s{0,}"\K[^"]+')
     if [ -z "$token" ]; then
         echo -n -e "\r Eurosport RO:\t\t\t\t${Font_Red}Failed (Error: PAGER ERROR)${Font_Suffix}\n"
         return
@@ -3392,8 +3395,8 @@ function MediaUnlockTest_EurosportRO() {
     local sourceSystemId='eurosport-vid2133403'
     local tmpresult1=$(curl ${CURL_DEFAULT_OPTS} -s "https://eu3-prod-direct.eurosport.ro/playback/v2/videoPlaybackInfo/sourceSystemId/${sourceSystemId}?usePreAuth=true" -H "Authorization: Bearer ${token}" --user-agent "${UA_BROWSER}")
 
-    local isBlocked=$(echo "$tmpresult1" | grep 'access.denied.geoblocked')
-    local isOK=$(echo "$tmpresult1" | grep 'eurosport-vod')
+    local isBlocked=$(echo "$tmpresult1" | $grep 'access.denied.geoblocked')
+    local isOK=$(echo "$tmpresult1" | $grep 'eurosport-vod')
 
     if [ -z "$isBlocked" ] && [ -z "$isOK" ]; then
         echo -n -e "\r Eurosport RO:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -3424,7 +3427,7 @@ function MediaUnlockTest_Channel5() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"code"\s{0,}:\s{0,}"\K[^"]+')
+    local result=$(echo "$tmpresult" | $grep -woP '"code"\s{0,}:\s{0,}"\K[^"]+')
 
     case "$result" in
         '3000') echo -n -e "\r Channel 5:\t\t\t\t${Font_Red}No${Font_Suffix}\n" ;;
@@ -3449,7 +3452,7 @@ function MediaUnlockTest_MyVideo() {
     fi
 
     local urlEffective=$(echo "$tmpresult" | awk -F'_TAG_' '{print $2}')
-    local isBlocked=$(echo "$urlEffective" | grep -i 'serviceAreaBlock')
+    local isBlocked=$(echo "$urlEffective" | $grep -i 'serviceAreaBlock')
 
     if [ -n "$isBlocked" ]; then
         echo -n -e "\r MyVideo:\t\t\t\t${Font_Red}No${Font_Suffix}\n"
@@ -3501,7 +3504,7 @@ function MediaUnlockTest_Channel10() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"allow"\s{0,}:\s{0,}\K(false|true)')
+    local result=$(echo "$tmpresult" | $grep -woP '"allow"\s{0,}:\s{0,}\K(false|true)')
     if [ -z "$result" ]; then
         echo -n -e "\r Channel 10:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
         return
@@ -3526,9 +3529,9 @@ function MediaUnlockTest_Spotify() {
         return
     fi
 
-    local statusCode=$(echo "$tmpresult" | grep -woP '"status"\s{0,}:\s{0,}\K\d+')
-    local region=$(echo "$tmpresult" | grep -woP '"country"\s{0,}:\s{0,}"\K[^"]+')
-    local isLaunched=$(echo "$tmpresult" | grep -woP '"is_country_launched"\s{0,}:\s{0,}\K(false|true)')
+    local statusCode=$(echo "$tmpresult" | $grep -woP '"status"\s{0,}:\s{0,}\K\d+')
+    local region=$(echo "$tmpresult" | $grep -woP '"country"\s{0,}:\s{0,}"\K[^"]+')
+    local isLaunched=$(echo "$tmpresult" | $grep -woP '"is_country_launched"\s{0,}:\s{0,}\K(false|true)')
 
     if [ -z "$statusCode" ]; then
         echo -n -e "\r Spotify Registration:\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -3567,8 +3570,8 @@ function MediaUnlockTest_VideoMarket() {
         return
     fi
 
-    local isBlocked=$(echo "$tmpresult" | grep 'OverseasAccess')
-    local isOK=$(echo "$tmpresult" | grep '292072')
+    local isBlocked=$(echo "$tmpresult" | $grep 'OverseasAccess')
+    local isOK=$(echo "$tmpresult" | $grep '292072')
 
     if [ -z "$isBlocked" ] && [ -z "$isOK" ]; then
         echo -n -e "\r VideoMarket:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -3605,9 +3608,9 @@ function MediaUnlockTest_musicjp() {
 
      local tmpresult=$(curl ${CURL_DEFAULT_OPTS} -sL 'https://overseaauth.music-book.jp/globalIpcheck.js' -w '_TAG_%{http_code}' --user-agent "${UA_BROWSER}")
 
-    local httpCode=$(echo "$tmpresult" | grep '_TAG_' | awk -F'_TAG_' '{print $2}')
+    local httpCode=$(echo "$tmpresult" | $grep '_TAG_' | awk -F'_TAG_' '{print $2}')
     local respContent=$(echo "$tmpresult" | awk -F'_TAG_' '{print $1}')
-    local isOK=$(echo "$respContent" | grep -i 'checkIp')
+    local isOK=$(echo "$respContent" | $grep -i 'checkIp')
 
     if [ "$httpCode" == '000' ]; then
         echo -n -e "\r music.jp:\t\t\t\t${Font_Red}Failed (Network Connection)${Font_Suffix}\n"
@@ -3636,13 +3639,13 @@ function MediaUnlockTest_InstagramMusic() {
         return
     fi
 
-    local isBlocked=$(echo "$tmpresult" | grep -i 'Rate limit exceeded')
+    local isBlocked=$(echo "$tmpresult" | $grep -i 'Rate limit exceeded')
     if [ -n "$isBlocked" ]; then
         echo -n -e "\r Instagram Licensed Audio:\t\t${Font_Red}No${Font_Suffix}\n"
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"should_mute_audio"\s{0,}:\s{0,}\K(false|true)')
+    local result=$(echo "$tmpresult" | $grep -woP '"should_mute_audio"\s{0,}:\s{0,}\K(false|true)')
 
     case "$result" in
         'false') echo -n -e "\r Instagram Licensed Audio:\t\t${Font_Green}Yes${Font_Suffix}\n" ;;
@@ -3693,8 +3696,8 @@ function MediaUnlockTest_TubiTV() {
         return
     fi
 
-    local isBlocked=$(echo "$tmpresult" | grep -i 'not currently available in your area')
-    local isOK=$(echo "$tmpresult" | grep -i 'manifest')
+    local isBlocked=$(echo "$tmpresult" | $grep -i 'not currently available in your area')
+    local isOK=$(echo "$tmpresult" | $grep -i 'manifest')
 
     if [ -z "$isBlocked" ] && [ -z "$isOK" ]; then
         echo -n -e "\r Tubi TV:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -3725,7 +3728,7 @@ function MediaUnlockTest_Philo() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"status"\s{0,}:\s{0,}"\K[^"]+')
+    local result=$(echo "$tmpresult" | $grep -woP '"status"\s{0,}:\s{0,}"\K[^"]+')
     if [ -z "$result" ]; then
         echo -n -e "\r Philo:\t\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
         return
@@ -3750,8 +3753,8 @@ function MediaUnlockTest_FXNOW() {
         return
     fi
 
-    local isBlocked=$(echo "$tmpresult" | grep -i 'is not accessible')
-    local isOK=$(echo "$tmpresult" | grep -i "FX Movies")
+    local isBlocked=$(echo "$tmpresult" | $grep -i 'is not accessible')
+    local isOK=$(echo "$tmpresult" | $grep -i "FX Movies")
 
     if [ -z "$isBlocked" ] && [ -z "$isOK" ]; then
         echo -n -e "\r FXNOW:\t\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -3782,7 +3785,7 @@ function MediaUnlockTest_Crunchyroll() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep "'code':'us'")
+    local result=$(echo "$tmpresult" | $grep "'code':'us'")
     if [ -z "$result" ]; then
         echo -n -e "\r Crunchyroll:\t\t\t\t${Font_Red}No${Font_Suffix}\n"
     else
@@ -3808,8 +3811,8 @@ function MediaUnlockTest_Shudder() {
         return
     fi
 
-    local isBlocked=$(echo "$tmpresult" | grep -iE 'not available|not yet available|403 ERROR')
-    local isOK=$(echo "$tmpresult" | grep -i 'movies')
+    local isBlocked=$(echo "$tmpresult" | $grep -iE 'not available|not yet available|403 ERROR')
+    local isOK=$(echo "$tmpresult" | $grep -i 'movies')
 
     if [ -z "$isBlocked" ] && [ -z "$isOK" ]; then
         echo -n -e "\r Shudder:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -3841,7 +3844,7 @@ function MediaUnlockTest_TLCGO() {
         return
     fi
 
-    local token=$(echo "$tmpresult" | grep -woP '"token"\s{0,}:\s{0,}"\K[^"]+')
+    local token=$(echo "$tmpresult" | $grep -woP '"token"\s{0,}:\s{0,}"\K[^"]+')
     if [ -z "$token" ]; then
         echo -n -e "\r TLC GO:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
         return
@@ -3849,9 +3852,9 @@ function MediaUnlockTest_TLCGO() {
 
     local tmpresult1=$(curl ${CURL_DEFAULT_OPTS} -s 'https://us1-prod-direct.tlc.com/cms/routes/home?include=default&decorators=viewingHistory,isFavorite,playbackAllowed&page\[items.number\]=1&page\[items.size\]=8' -H 'accept-language: en-US,en;q=0.9' -H "Authorization: Bearer ${token}" -H 'origin: https://go.tlc.com' -H 'referer: https://go.tlc.com/' -H "sec-ch-ua: ${UA_SEC_CH_UA}" -H 'sec-ch-ua-mobile: ?0' -H 'sec-ch-ua-platform: "Windows"' -H 'sec-fetch-dest: empty' -H 'sec-fetch-mode: cors' -H 'sec-fetch-site: same-site' -H 'x-disco-client: WEB:UNKNOWN:tlc:3.17.0' -H 'x-disco-params: realm=go,siteLookupKey=tlc,bid=tlc,hn=go.tlc.com,hth=us,features=ar' --user-agent "${UA_BROWSER}")
 
-    local isBlocked=$(echo "$tmpresult1" | grep -i 'is not yet available')
-    local isOK=$(echo "$tmpresult1" | grep -i 'Episodes')
-    local region=$(echo "$tmpresult1" | grep -woP '"mainTerritoryCode"\s{0,}:\s{0,}"\K[^"]+' | tr a-z A-Z)
+    local isBlocked=$(echo "$tmpresult1" | $grep -i 'is not yet available')
+    local isOK=$(echo "$tmpresult1" | $grep -i 'Episodes')
+    local region=$(echo "$tmpresult1" | $grep -woP '"mainTerritoryCode"\s{0,}:\s{0,}"\K[^"]+' | tr a-z A-Z)
 
     if [ -z "$isBlocked" ] && [ -z "$isOK" ]; then
         echo -n -e "\r TLC GO:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -3877,8 +3880,8 @@ function RegionTest_oneTrust() {
         return
     fi
 
-    local region=$(echo "$tmpresult" | grep -woP '"country"\s{0,}:\s{0,}"\K[^"]+')
-    local stateName=$(echo "$tmpresult" | grep -woP '"stateName"\s{0,}:\s{0,}"\K[^"]+')
+    local region=$(echo "$tmpresult" | $grep -woP '"country"\s{0,}:\s{0,}"\K[^"]+')
+    local stateName=$(echo "$tmpresult" | $grep -woP '"stateName"\s{0,}:\s{0,}"\K[^"]+')
     if [ -z "$region" ]; then
         echo -n -e "\r OneTrust Region:\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
         return
@@ -3921,8 +3924,8 @@ function MediaUnlockTest_Tving() {
         return
     fi
 
-    local isBlocked=$(echo "$tmpresult" | grep -i 'available in South Korea')
-    local isOK=$(echo "$tmpresult" | grep 'vod_type')
+    local isBlocked=$(echo "$tmpresult" | $grep -i 'available in South Korea')
+    local isOK=$(echo "$tmpresult" | $grep 'vod_type')
 
     if [ -z "$isBlocked" ] && [ -z "$isOK" ]; then
         echo -n -e "\r Tving:\t\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -3956,7 +3959,7 @@ function MediaUnlockTest_CoupangPlay() {
     fi
 
     local urlEffective=$(echo "$tmpresult" | awk -F'_TAG_' '{print $2}')
-    local isBlocked=$(echo "$urlEffective" | grep -i 'not-available')
+    local isBlocked=$(echo "$urlEffective" | $grep -i 'not-available')
 
     if [ -n "$isBlocked" ]; then
         echo -n -e "\r Coupang Play:\t\t\t\t${Font_Red}No${Font_Suffix}\n"
@@ -3994,7 +3997,7 @@ function MediaUnlockTest_NaverTV() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"playable"\s{0,}:\s{0,}"\K[^"]+')
+    local result=$(echo "$tmpresult" | $grep -woP '"playable"\s{0,}:\s{0,}"\K[^"]+')
 
     case "$result" in
         'NOT_COUNTRY_AVAILABLE') echo -n -e "\r Naver TV:\t\t\t\t${Font_Red}No${Font_Suffix}\n" ;;
@@ -4016,7 +4019,7 @@ function MediaUnlockTest_Afreeca() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep "document.location.href='https://vod.afreecatv.com'" )
+    local result=$(echo "$tmpresult" | $grep "document.location.href='https://vod.afreecatv.com'" )
     if [ -z "$result" ]; then
         echo -n -e "\r Afreeca TV:\t\t\t\t${Font_Green}Yes${Font_Suffix}\n"
     else
@@ -4036,7 +4039,7 @@ function MediaUnlockTest_KBSDomestic() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep 'ipck' | grep -woP 'Domestic\\\"\s{0,}:\s{0,}\K(false|true)')
+    local result=$(echo "$tmpresult" | $grep 'ipck' | $grep -woP 'Domestic\\\"\s{0,}:\s{0,}\K(false|true)')
 
     if [ -z "$result" ]; then
         echo -n -e "\r KBS Domestic:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -4066,7 +4069,7 @@ function MediaUnlockTest_KBSAmerican() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep 'ipck' | grep -woP 'Domestic\\\"\s{0,}:\s{0,}\K(false|true)')
+    local result=$(echo "$tmpresult" | $grep 'ipck' | $grep -woP 'Domestic\\\"\s{0,}:\s{0,}\K(false|true)')
 
     if [ -z "$result" ]; then
         echo -n -e "\r KBS American:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -4128,7 +4131,7 @@ function MediaUnlockTest_NBCTV() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"restricted"\s{0,}:\s{0,}\K(false|true)')
+    local result=$(echo "$tmpresult" | $grep -woP '"restricted"\s{0,}:\s{0,}\K(false|true)')
 
     case "$result" in
         'false') echo -n -e "\r NBC TV:\t\t\t\t${Font_Green}Yes${Font_Suffix}\n" ;;
@@ -4141,13 +4144,13 @@ function MediaUnlockTest_NBCTV() {
 function MediaUnlockTest_Crackle() {
     local tmpresult=$(curl ${CURL_DEFAULT_OPTS} -sLi 'https://prod-api.crackle.com/appconfig' -w "_TAG_%{http_code}_TAG_" -H 'Accept-Language: en-US,en;q=0.9' -H 'Content-Type: application/json' -H 'Origin: https://www.crackle.com' -H 'Referer: https://www.crackle.com/' -H 'Sec-Fetch-Dest: empty' -H 'Sec-Fetch-Mode: cors' -H 'Sec-Fetch-Site: same-site' -H "sec-ch-ua: ${UA_SEC_CH_UA}" -H 'sec-ch-ua-mobile: ?0' -H 'sec-ch-ua-platform: "Windows"' -H 'x-crackle-apiversion: v2.0.0' -H 'x-crackle-brand: crackle' -H 'x-crackle-platform: 5FE67CCA-069A-42C6-A20F-4B47A8054D46' --user-agent "${UA_BROWSER}")
 
-    local httpCode=$(echo "$tmpresult" | grep '_TAG_' | awk -F'_TAG_' '{print $2}')
+    local httpCode=$(echo "$tmpresult" | $grep '_TAG_' | awk -F'_TAG_' '{print $2}')
     if [ "$httpCode" == '000' ]; then
         echo -n -e "\r Crackle:\t\t\t\t${Font_Red}Failed (Network Connection)${Font_Suffix}\n"
         return
     fi
 
-    local region=$(echo "$tmpresult" | grep -woP 'x-crackle-region:\s{0,}\K[A-Z]+')
+    local region=$(echo "$tmpresult" | $grep -woP 'x-crackle-region:\s{0,}\K[A-Z]+')
 
     if [ -z "$region" ]; then
         echo -n -e "\r Crackle:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -4172,7 +4175,7 @@ function MediaUnlockTest_AETV() {
         return
     fi
 
-    local isBlocked=$(echo "$tmpresult" | grep -i 'GeoLocationBlocked')
+    local isBlocked=$(echo "$tmpresult" | $grep -i 'GeoLocationBlocked')
     if [ -n "$isBlocked" ]; then
         echo -n -e "\r A&E TV:\t\t\t\t${Font_Red}No${Font_Suffix}\n"
         return
@@ -4180,7 +4183,7 @@ function MediaUnlockTest_AETV() {
 
     local tmpresult1=$(curl ${CURL_DEFAULT_OPTS} -s 'https://play.aetv.com/' -o /dev/null -D - --user-agent "${UA_BROWSER}")
 
-    local region=$(echo "$tmpresult1" | grep -woP 'AETN-Country-Code=\K[A-Z]+' | head -n 1)
+    local region=$(echo "$tmpresult1" | $grep -woP 'AETN-Country-Code=\K[A-Z]+' | head -n 1)
     if [ -z "$region" ]; then
         echo -n -e "\r A&E TV:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
         return
@@ -4206,7 +4209,7 @@ function MediaUnlockTest_NFLPlus() {
     fi
 
     local urlEffective=$(echo "$tmpresult" | awk -F'_TAG_' '{print $2}')
-    local isBlocked=$(echo "$urlEffective" | grep -iE 'nfl-game-pass|gpi.nfl.com')
+    local isBlocked=$(echo "$urlEffective" | $grep -iE 'nfl-game-pass|gpi.nfl.com')
 
     if [ -n "$isBlocked" ]; then
         echo -n -e "\r NFL+:\t\t\t\t\t${Font_Red}No${Font_Suffix}\n"
@@ -4223,7 +4226,7 @@ function MediaUnlockTest_NFLPlus() {
 function MediaUnlockTest_SkyShowTime() {
     local tmpresult=$(curl ${CURL_DEFAULT_OPTS} -fsL 'https://www.skyshowtime.com/' -w "_TAG_%{http_code}_TAG_" -o /dev/null -D - -H 'accept: */*;q=0.8,application/signed-exchange;v=b3;q=0.9' -H 'accept-language: en-US,en;q=0.9' --user-agent "${UA_BROWSER}")
 
-    local httpCode=$(echo "$tmpresult" | grep '_TAG_' | awk -F'_TAG_' '{print $2}')
+    local httpCode=$(echo "$tmpresult" | $grep '_TAG_' | awk -F'_TAG_' '{print $2}')
     if [ "$httpCode" == '000' ]; then
         echo -n -e "\r SkyShowTime:\t\t\t\t${Font_Red}Failed (Network Connection)${Font_Suffix}\n"
         return
@@ -4234,13 +4237,13 @@ function MediaUnlockTest_SkyShowTime() {
         return
     fi
 
-    local isBlocked=$(echo "$tmpresult" | grep -i 'where-can-i-stream')
+    local isBlocked=$(echo "$tmpresult" | $grep -i 'where-can-i-stream')
     if [ -n "$isBlocked" ]; then
         echo -n -e "\r SkyShowTime:\t\t\t\t${Font_Red}No${Font_Suffix}\n"
         return
     fi
 
-    local region=$(echo "$tmpresult" | grep -woP 'activeTerritory=\K[A-Z]+' | head -n 1)
+    local region=$(echo "$tmpresult" | $grep -woP 'activeTerritory=\K[A-Z]+' | head -n 1)
     if [ -z "$region" ]; then
         echo -n -e "\r SkyShowTime:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
         return
@@ -4266,15 +4269,15 @@ function GameTest_MathsSpot() {
         return
     fi
 
-    local isBlocked=$(echo "$tmpresult" | grep -i 'FailureServiceNotInRegion')
+    local isBlocked=$(echo "$tmpresult" | $grep -i 'FailureServiceNotInRegion')
     if [ -n "$isBlocked" ]; then
         echo -n -e "\r MathsSpot Roblox:\t\t\t${Font_Red}No${Font_Suffix}\n"
         return
     fi
 
-    local apiPath=$(echo "$tmpresult" | grep -woP 'fetch\("\K[^"]+' | grep 'reportEvent' | sed 's/\/reportEvent//;s/^\///')
-    local region=$(echo "$tmpresult" | grep -woP '"countryCode"\s{0,}:\s{0,}"\K[^"]+')
-    local nggFeVersion=$(echo "$tmpresult" | grep -woP '"NEXT_PUBLIC_FE_VERSION"\s{0,}:\s{0,}"\K[^"]+')
+    local apiPath=$(echo "$tmpresult" | $grep -woP 'fetch\("\K[^"]+' | $grep 'reportEvent' | sed 's/\/reportEvent//;s/^\///')
+    local region=$(echo "$tmpresult" | $grep -woP '"countryCode"\s{0,}:\s{0,}"\K[^"]+')
+    local nggFeVersion=$(echo "$tmpresult" | $grep -woP '"NEXT_PUBLIC_FE_VERSION"\s{0,}:\s{0,}"\K[^"]+')
     if [ -z "$apiPath" ] || [ -z "$nggFeVersion" ] || [ -z "$region" ]; then
         echo -n -e "\r MathsSpot Roblox:\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
         return
@@ -4291,7 +4294,7 @@ function GameTest_MathsSpot() {
         return
     fi
 
-    local status=$(echo "$tmpresult1" |  grep -woP '"status"\s{0,}:\s{0,}"\K[^"]+' | head -n 1)
+    local status=$(echo "$tmpresult1" |  $grep -woP '"status"\s{0,}:\s{0,}"\K[^"]+' | head -n 1)
     if [ -z "$status" ]; then
         echo -n -e "\r MathsSpot Roblox:\t\t\t${Font_Red}Failed (Error: PAGE ERROR 1)${Font_Suffix}\n"
         return
@@ -4317,7 +4320,7 @@ function MediaUnlockTest_BGlobalSEA() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"code"\s{0,}:\s{0,}\K[-\d]+' | head -n 1)
+    local result=$(echo "$tmpresult" | $grep -woP '"code"\s{0,}:\s{0,}\K[-\d]+' | head -n 1)
 
     case "$result" in
         '0') echo -n -e "\r B-Global SouthEastAsia:\t\t${Font_Green}Yes${Font_Suffix}\n" ;;
@@ -4338,7 +4341,7 @@ function MediaUnlockTest_BGlobalTH() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"code"\s{0,}:\s{0,}\K[-\d]+' | head -n 1)
+    local result=$(echo "$tmpresult" | $grep -woP '"code"\s{0,}:\s{0,}\K[-\d]+' | head -n 1)
 
     case "$result" in
         '0') echo -n -e "\r B-Global Thailand Only:\t\t${Font_Green}Yes${Font_Suffix}\n" ;;
@@ -4359,7 +4362,7 @@ function MediaUnlockTest_BGlobalID() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"code"\s{0,}:\s{0,}\K[-\d]+' | head -n 1)
+    local result=$(echo "$tmpresult" | $grep -woP '"code"\s{0,}:\s{0,}\K[-\d]+' | head -n 1)
 
     case "$result" in
         '0') echo -n -e "\r B-Global Indonesia Only:\t\t${Font_Green}Yes${Font_Suffix}\n" ;;
@@ -4380,7 +4383,7 @@ function MediaUnlockTest_BGlobalVN() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"code"\s{0,}:\s{0,}\K[-\d]+' | head -n 1)
+    local result=$(echo "$tmpresult" | $grep -woP '"code"\s{0,}:\s{0,}\K[-\d]+' | head -n 1)
 
     case "$result" in
         '0') echo -n -e "\r B-Global Việt Nam Only:\t\t${Font_Green}Yes${Font_Suffix}\n" ;;
@@ -4406,8 +4409,8 @@ function MediaUnlockTest_AISPlay() {
         return
     fi
 
-    local sId=$(echo "$tmpresult" | grep -woP '"sid"\s{0,}:\s{0,}"\K[^"]+')
-    local datAuth=$(echo "$tmpresult" | grep -woP '"dat"\s{0,}:\s{0,}"\K[^"]+')
+    local sId=$(echo "$tmpresult" | $grep -woP '"sid"\s{0,}:\s{0,}"\K[^"]+')
+    local datAuth=$(echo "$tmpresult" | $grep -woP '"dat"\s{0,}:\s{0,}"\K[^"]+')
     # 新时间戳
     local timestamp=$(date +%s)
     # 取播放模板
@@ -4417,7 +4420,7 @@ function MediaUnlockTest_AISPlay() {
         return
     fi
 
-    local tmpLiveUrl=$(echo "$tmpresult1" | grep -woP '"live"\s{0,}:\s{0,}"\K[^"]+')
+    local tmpLiveUrl=$(echo "$tmpresult1" | $grep -woP '"live"\s{0,}:\s{0,}"\K[^"]+')
     if [ -z "$tmpLiveUrl" ]; then
         echo -n -e "\r AIS Play:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
         return
@@ -4432,7 +4435,7 @@ function MediaUnlockTest_AISPlay() {
     local tmpresult2=$(curl ${CURL_DEFAULT_OPTS} -sL "$realLiveUrl" -H 'Accept-Language: en-US,en;q=0.9' -H 'Origin: https://web-player.ais-vidnt.com' -H 'Referer: https://web-player.ais-vidnt.com/' -H 'Sec-Fetch-Dest: empty' -H 'Sec-Fetch-Mode: cors' -H 'Sec-Fetch-Site: same-site' -H "sec-ch-ua: ${UA_SEC_CH_UA}" -H 'sec-ch-ua-mobile: ?0' -H 'sec-ch-ua-platform: "Windows"' --user-agent "${UA_BROWSER}")
 
     # 取第一优先级播放地址
-    local playUrl=$(echo "$tmpresult2" | grep -woP '"url"\s{0,}:\s{0,}"\K[^"]+' | grep 'rewriter' | head -n 1)
+    local playUrl=$(echo "$tmpresult2" | $grep -woP '"url"\s{0,}:\s{0,}"\K[^"]+' | $grep 'rewriter' | head -n 1)
     if [ -z "$playUrl" ]; then
         echo -n -e "\r AIS Play:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
         return
@@ -4441,7 +4444,7 @@ function MediaUnlockTest_AISPlay() {
     local tmpresult3=$(curl ${CURL_DEFAULT_OPTS} -sLi "$playUrl" -H 'Accept-Language: en-US,en;q=0.9' -H 'Origin: https://web-player.ais-vidnt.com' -H 'Referer: https://web-player.ais-vidnt.com/' -H 'Sec-Fetch-Dest: empty' -H 'Sec-Fetch-Mode: cors' -H 'Sec-Fetch-Site: same-site' -H "sec-ch-ua: ${UA_SEC_CH_UA}" -H 'sec-ch-ua-mobile: ?0' -H 'sec-ch-ua-platform: "Windows"' --user-agent "${UA_BROWSER}")
 
     # X-Base-Request-Check-Status: INCORRECT X-Geo-Protection-System-Status: BLOCK
-    local baseRequstCheckStatus=$(echo "$tmpresult3" | grep -woP 'X-Base-Request-Check-Status:\s{0,}\K\w+')
+    local baseRequstCheckStatus=$(echo "$tmpresult3" | $grep -woP 'X-Base-Request-Check-Status:\s{0,}\K\w+')
     if [ -z "$baseRequstCheckStatus" ]; then
         echo -n -e "\r AIS Play:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
         return
@@ -4451,7 +4454,7 @@ function MediaUnlockTest_AISPlay() {
         return
     fi
 
-    local result="$(echo "$tmpresult3" | grep -woP 'X-Geo-Protection-System-Status:\s{0,}\K\w+')"
+    local result="$(echo "$tmpresult3" | $grep -woP 'X-Geo-Protection-System-Status:\s{0,}\K\w+')"
 
     case "$result" in
         'BLOCK') echo -n -e "\r AIS Play:\t\t\t\t${Font_Red}No${Font_Suffix}\n" ;;
@@ -4473,8 +4476,8 @@ function WebTest_OpenAI() {
         return
     fi
 
-    local result1=$(echo "$tmpresult1" | grep -i 'unsupported_country')
-    local result2=$(echo "$tmpresult2" | grep -i 'VPN')
+    local result1=$(echo "$tmpresult1" | $grep -i 'unsupported_country')
+    local result2=$(echo "$tmpresult2" | $grep -i 'VPN')
     if [ -z "$result2" ] && [ -z "$result1" ]; then
         echo -n -e "\r ChatGPT:\t\t\t\t${Font_Green}Yes${Font_Suffix}\n"
         return
@@ -4502,8 +4505,8 @@ function WebTest_MetaAI() {
         return
     fi
 
-    local isBlocked=$(echo "$tmpresult" | grep -i 'AbraGeoBlockedErrorRoot')
-    local isOK=$(echo "$tmpresult" | grep -i 'AbraHomeRootConversationQuery')
+    local isBlocked=$(echo "$tmpresult" | $grep -i 'AbraGeoBlockedErrorRoot')
+    local isOK=$(echo "$tmpresult" | $grep -i 'AbraHomeRootConversationQuery')
 
     if [ -z "$isBlocked" ] && [ -z "$isOK" ]; then
         echo -n -e "\r Meta AI:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -4516,7 +4519,7 @@ function WebTest_MetaAI() {
     fi
 
     if [ -n "$isOK" ]; then
-        local region=$(echo "$tmpresult" | grep -woP '"code"\s{0,}:\s{0,}"\K[^"]+' | cut -d'_' -f2)
+        local region=$(echo "$tmpresult" | $grep -woP '"code"\s{0,}:\s{0,}"\K[^"]+' | cut -d'_' -f2)
         echo -n -e "\r Meta AI:\t\t\t\t${Font_Green}Yes (Region: ${region})${Font_Suffix}\n"
         return
     fi
@@ -4531,8 +4534,8 @@ function RegionTest_Bing() {
         return
     fi
 
-    local isCN=$(echo "$tmpresult" | grep 'cn.bing.com')
-    local region=$(echo "$tmpresult" | grep -woP 'Region\s{0,}:\s{0,}"\K[^"]+')
+    local isCN=$(echo "$tmpresult" | $grep 'cn.bing.com')
+    local region=$(echo "$tmpresult" | $grep -woP 'Region\s{0,}:\s{0,}"\K[^"]+')
 
     if [ -n "$isCN" ]; then
         local region='CN'
@@ -4550,7 +4553,7 @@ function WebTest_Wikipedia_Editable() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -i 'Banned')
+    local result=$(echo "$tmpresult" | $grep -i 'Banned')
     if [ -z "$result" ]; then
         echo -n -e "\r Wikipedia Editability:\t\t\t${Font_Green}Yes${Font_Suffix}\n"
         return
@@ -4565,7 +4568,7 @@ function MediaUnlockTest_K_PLUS() {
         return
     fi
 
-    local token=$(curl ${CURL_DEFAULT_OPTS} -s -H "Origin: https://xem.kplus.vn" -H "Referer: https://xem.kplus.vn/" -X POST -d '{"osVersion":"Windows NT 10.0","appVersion":"114.0.0.0","deviceModel":"Chrome","deviceType":"PC","deviceSerial":"w39db81c0-a2e9-11ed-952a-49b91c9e6f09","deviceOem":"Chrome","devicePrettyName":"Chrome","ssoToken":"eyJrZXkiOiJ2c3R2IiwiZW5jIjoiQTEyOENCQy1IUzI1NiIsImFsZyI6ImRpciJ9..MWbBlLuci2KNLl9lvMe63g.IbBX7-dg3BWaXzzoxTQz-pJFulm_Y8axWLuG5DcJxQ9jTUPOhA2e6dzOP2hryAFVPFoIRs97ONGTHEYTFQgUtRlvqvx53jyTi3yegU6zWhJnhYZA2sdaj9khsNvVAth0zcWFoWA9GGwfNE5TZLOwczAexIxqC1Ee-tQDILC4XklFrJfvdzoCQBABRXpD_O4HHHIYFs0jBMtYSyD9Vq7dTD61sAVca_83lav7jvpP17PuAo3HHIFQtUdcugpgkB91mJbABIDTPdo0mqdzbgTA_FilwO1Z5qnpwqIZIXy0bhVXFFcwUZPIUxjLEVzP3SyHceFF5N-v7OeYhYZRLYuBKxWj1cRb3LAa3FGJvefqRsBadlsr0cZnOgx0TsL51a2SaIpNyyGtaq8KTTLULIZBb2Zsq2jmBkZtxjoPxUR8ku7J4sL0tfLDoMlWVZkrX4_1tls3E-l8Ael-wd0kbS1i2vpf-Vdh80lRClpDg3ibSSUFPsp3wYMFsuKfyY8vpHrCfYDJDDbYOSv20sfnU7q7gcmizTCFBuiszmXbFX9_aH8UOaCGeqkYDV1ZZ3mQ26TM7JEquuZTV09wdi81ABoM8RZcb2ua0cuocaO4-asMh8KQWNea9BCYlKK5NSPz--oGgGxSdvxZ63qQz1Lr4QZytA2buoQV5OlMoEP7k87fPcig5rPqsK7aeWUXJSmfiOBbSLztoiamvvHClMpds3frv0ud8NWUUoijmS_JUGfF7XYNxWWqEGJuDUoSllV5MVwtIb5wM069gR7zknrr5aRVDi3Nho16KHQ_iB3vxoIr-ExajWLNlvo44CopGhxhgOAKPkULV356uamZpB7twY_iEVrwGMQA1_hEH4usO-UbzuxL_pssLhJKD4NjVcTe86Z08Bfm0IyiNWESmFkA6FVfsxu57Yfd4bXT8mxnfXXmklb7u7vB0RVYRo4i26QGJbPknybHdfgQWEvRCMoAjEG-E2LymBAMwFneWEpPTwBMpfvlTHnGnUtfViA4Zy1xqF2q95g9AF9nF3sE4YpYuSFSkUQB4sZd8emDApIdP6Avqsq809Gg06_R2sUGrD9SQ-XbXhvtAYMcaUcSv54hJvRcSUkygqU8tdg4tJHR23UBb-I.UfpC5BKhvt8EE5gpIFMQoQ","brand":"vstv","environment":"p","language":"en_US","memberId":"0","featureLevel":4,"provisionData":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYyI6dHJ1ZSwiaWF0IjoxNjg2NTc4NzYyLCJ1cCI6ImNwaSIsImRlIjoiYnJhbmRNYXBwaW5nIiwiYnIiOiJ2c3R2IiwiZHMiOiJ3MzlkYjgxYzAtYTJlOS0xMWVkLTk1MmEtNDliOTFjOWU2ZjA5In0.3mbI7wnJKtRf3493yc_ZEMEvzUXldwDx0sSZdwQnlNk"}' "https://tvapi-sgn.solocoo.tv/v1/session" |  grep -woP '"token"\s{0,}:\s{0,}"\K[^"]+' | awk '{print $2}' | cut -f2 -d'"')
+    local token=$(curl ${CURL_DEFAULT_OPTS} -s -H "Origin: https://xem.kplus.vn" -H "Referer: https://xem.kplus.vn/" -X POST -d '{"osVersion":"Windows NT 10.0","appVersion":"114.0.0.0","deviceModel":"Chrome","deviceType":"PC","deviceSerial":"w39db81c0-a2e9-11ed-952a-49b91c9e6f09","deviceOem":"Chrome","devicePrettyName":"Chrome","ssoToken":"eyJrZXkiOiJ2c3R2IiwiZW5jIjoiQTEyOENCQy1IUzI1NiIsImFsZyI6ImRpciJ9..MWbBlLuci2KNLl9lvMe63g.IbBX7-dg3BWaXzzoxTQz-pJFulm_Y8axWLuG5DcJxQ9jTUPOhA2e6dzOP2hryAFVPFoIRs97ONGTHEYTFQgUtRlvqvx53jyTi3yegU6zWhJnhYZA2sdaj9khsNvVAth0zcWFoWA9GGwfNE5TZLOwczAexIxqC1Ee-tQDILC4XklFrJfvdzoCQBABRXpD_O4HHHIYFs0jBMtYSyD9Vq7dTD61sAVca_83lav7jvpP17PuAo3HHIFQtUdcugpgkB91mJbABIDTPdo0mqdzbgTA_FilwO1Z5qnpwqIZIXy0bhVXFFcwUZPIUxjLEVzP3SyHceFF5N-v7OeYhYZRLYuBKxWj1cRb3LAa3FGJvefqRsBadlsr0cZnOgx0TsL51a2SaIpNyyGtaq8KTTLULIZBb2Zsq2jmBkZtxjoPxUR8ku7J4sL0tfLDoMlWVZkrX4_1tls3E-l8Ael-wd0kbS1i2vpf-Vdh80lRClpDg3ibSSUFPsp3wYMFsuKfyY8vpHrCfYDJDDbYOSv20sfnU7q7gcmizTCFBuiszmXbFX9_aH8UOaCGeqkYDV1ZZ3mQ26TM7JEquuZTV09wdi81ABoM8RZcb2ua0cuocaO4-asMh8KQWNea9BCYlKK5NSPz--oGgGxSdvxZ63qQz1Lr4QZytA2buoQV5OlMoEP7k87fPcig5rPqsK7aeWUXJSmfiOBbSLztoiamvvHClMpds3frv0ud8NWUUoijmS_JUGfF7XYNxWWqEGJuDUoSllV5MVwtIb5wM069gR7zknrr5aRVDi3Nho16KHQ_iB3vxoIr-ExajWLNlvo44CopGhxhgOAKPkULV356uamZpB7twY_iEVrwGMQA1_hEH4usO-UbzuxL_pssLhJKD4NjVcTe86Z08Bfm0IyiNWESmFkA6FVfsxu57Yfd4bXT8mxnfXXmklb7u7vB0RVYRo4i26QGJbPknybHdfgQWEvRCMoAjEG-E2LymBAMwFneWEpPTwBMpfvlTHnGnUtfViA4Zy1xqF2q95g9AF9nF3sE4YpYuSFSkUQB4sZd8emDApIdP6Avqsq809Gg06_R2sUGrD9SQ-XbXhvtAYMcaUcSv54hJvRcSUkygqU8tdg4tJHR23UBb-I.UfpC5BKhvt8EE5gpIFMQoQ","brand":"vstv","environment":"p","language":"en_US","memberId":"0","featureLevel":4,"provisionData":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYyI6dHJ1ZSwiaWF0IjoxNjg2NTc4NzYyLCJ1cCI6ImNwaSIsImRlIjoiYnJhbmRNYXBwaW5nIiwiYnIiOiJ2c3R2IiwiZHMiOiJ3MzlkYjgxYzAtYTJlOS0xMWVkLTk1MmEtNDliOTFjOWU2ZjA5In0.3mbI7wnJKtRf3493yc_ZEMEvzUXldwDx0sSZdwQnlNk"}' "https://tvapi-sgn.solocoo.tv/v1/session" |  $grep -woP '"token"\s{0,}:\s{0,}"\K[^"]+' | awk '{print $2}' | cut -f2 -d'"')
     if [ -z "$token" ]; then
         echo -n -e "\r K+:\t\t\t\t\t${Font_Red}Failed (Network Connection)${Font_Suffix}\n"
         return
@@ -4577,7 +4580,7 @@ function MediaUnlockTest_K_PLUS() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep 'geoblock')
+    local result=$(echo "$tmpresult" | $grep 'geoblock')
 
     if [ -n "$result" ]; then
         echo -n -e "\r K+:\t\t\t\t\t${Font_Red}No${Font_Suffix}\n"
@@ -4599,7 +4602,7 @@ function MediaUnlockTest_TV360() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -woP '"errorCode"\s{0,}:\s{0,}\K\d+')
+    local result=$(echo "$tmpresult" | $grep -woP '"errorCode"\s{0,}:\s{0,}\K\d+')
 
     case "$result" in
         '310') echo -n -e "\r TV360:\t\t\t\t\t${Font_Red}No${Font_Suffix}\n" ;;
@@ -4620,8 +4623,8 @@ function MediaUnlockTest_MeWatch() {
         return
     fi
 
-    local isBlocked=$(echo "$tmpresult" | grep -woP '"code"\s{0,}:\s{0,}\K\d+')
-    local isOK=$(echo "$tmpresult" | grep -i 'Stream')
+    local isBlocked=$(echo "$tmpresult" | $grep -woP '"code"\s{0,}:\s{0,}\K\d+')
+    local isOK=$(echo "$tmpresult" | $grep -i 'Stream')
 
     if [ -z "$isBlocked" ] && [ -z "$isOK" ]; then
         echo -n -e "\r MeWatch:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -4651,12 +4654,12 @@ function MediaUnlockTest_trueID() {
         echo -n -e "\r trueID:\t\t\t\t${Font_Red}Failed (Network Connection)${Font_Suffix}\n"
         return
     fi
-    local channelId=$(echo "$tmpresult" | grep -woP '"channelId"\s{0,}:\s{0,}"\K[^"]+' | head -n 1)
-    local authUser=$(echo "$tmpresult" | grep -woP '"buildId"\s{0,}:\s{0,}"\K[^"]+' | head -n 1)
+    local channelId=$(echo "$tmpresult" | $grep -woP '"channelId"\s{0,}:\s{0,}"\K[^"]+' | head -n 1)
+    local authUser=$(echo "$tmpresult" | $grep -woP '"buildId"\s{0,}:\s{0,}"\K[^"]+' | head -n 1)
     local authKey=${authUser:10}
     local tmpresult2=$(curl ${CURL_DEFAULT_OPTS} -s "https://tv.trueid.net/api/stream/checkedPlay?channelId=${channelId}&lang=en&country=th" -H "sec-ch-ua: ${UA_SEC_CH_UA}" -H 'sec-ch-ua-mobile: ?0' -H 'sec-ch-ua-platform: "Windows"' -H 'sec-fetch-dest: document' -H 'sec-fetch-mode: navigate' -H 'sec-fetch-site: same-origin' -H 'sec-fetch-user: ?1' -H 'upgrade-insecure-requests: 1' -u ${authUser}:${authKey} -H 'accept: application/json, text/plain, */*' -H 'referer: https://tv.trueid.net/th-en/live/thairathtv-hd' --user-agent "${UA_BROWSER}")
 
-    local result=$(echo "$tmpresult2" | grep -woP '"billboardType"\s{0,}:\s{0,}"\K[^"]+')
+    local result=$(echo "$tmpresult2" | $grep -woP '"billboardType"\s{0,}:\s{0,}"\K[^"]+')
     case "$result" in
         'GEO_BLOCK') echo -n -e "\r trueID:\t\t\t\t${Font_Red}No${Font_Suffix}\n" ;;
         'LOADING') echo -n -e "\r trueID:\t\t\t\t${Font_Green}Yes${Font_Suffix}\n" ;;
@@ -4670,20 +4673,20 @@ function MediaUnlockTest_SonyLiv() {
         echo -n -e "\r SonyLiv:\t\t\t\t${Font_Red}Failed (Network Connection)${Font_Suffix}\n"
         return
     fi
-    local isBlocked=$(echo "$tmpresult" | grep 'geolocation_notsupported')
+    local isBlocked=$(echo "$tmpresult" | $grep 'geolocation_notsupported')
     if [ -n "$isBlocked" ]; then
         echo -n -e "\r SonyLiv:\t\t\t\t${Font_Red}No${Font_Suffix}\n"
         return
     fi
     # 取得 JWT Token
-    local jwtToken=$(echo "$tmpresult" | grep 'securityToken' | sed 's/.*securityToken//' | sed 's/.*resultObj//' | cut -f2 -d'"' | head -n 1)
+    local jwtToken=$(echo "$tmpresult" | $grep 'securityToken' | sed 's/.*securityToken//' | sed 's/.*resultObj//' | cut -f2 -d'"' | head -n 1)
     # 取得国家代码
     local tmpresult2=$(curl ${CURL_DEFAULT_OPTS} -s 'https://apiv2.sonyliv.com/AGL/1.4/A/ENG/WEB/ALL/USER/ULD' -H "sec-ch-ua: ${UA_SEC_CH_UA}" -H 'sec-ch-ua-mobile: ?0' -H 'sec-ch-ua-platform: "Windows"' -H 'accept: application/json, text/plain, */*' -H 'referer: https://www.sonyliv.com/' -H 'device_id: 25a417c3b5f246a393fadb022adc82d5-1715309762699' -H 'app_version: 3.5.59' -H "security_token: ${jwtToken}" --user-agent "${UA_BROWSER}")
     if [ -z "$tmpresult2" ]; then
         echo -n -e "\r SonyLiv:\t\t\t\t${Font_Red}Failed (Network Connection 1)${Font_Suffix}\n"
         return
     fi
-    local region=$(echo "$tmpresult2" |  grep -woP '"country_code"\s{0,}:\s{0,}"\K[^"]+')
+    local region=$(echo "$tmpresult2" |  $grep -woP '"country_code"\s{0,}:\s{0,}"\K[^"]+')
     # 取得播放详情
     local tmpresult3=$(curl ${CURL_DEFAULT_OPTS} -s "https://apiv2.sonyliv.com/AGL/3.8/A/ENG/WEB/${region}/ALL/CONTENT/VIDEOURL/VOD/1000045427/prefetch" -H "sec-ch-ua: ${UA_SEC_CH_UA}" -H 'sec-ch-ua-mobile: ?0' -H 'sec-ch-ua-platform: "Windows"' -H 'sec-fetch-dest: document' -H 'sec-fetch-mode: navigate' -H 'sec-fetch-site: same-origin' -H 'sec-fetch-user: ?1' -H 'upgrade-insecure-requests: 1' -H 'accept: application/json, text/plain, */*' -H 'origin: https://www.sonyliv.com' -H 'referer: https://www.sonyliv.com/' -H 'device_id: 25a417c3b5f246a393fadb022adc82d5-1715309762699' -H "security_token: ${jwtToken}" --user-agent "${UA_BROWSER}")
     if [ -z "$tmpresult3" ]; then
@@ -4691,8 +4694,8 @@ function MediaUnlockTest_SonyLiv() {
         return
     fi
 
-    local result=$(echo "$tmpresult3" | grep -woP '"resultCode"\s{0,}:\s{0,}"\K[^"]+')
-    local reason=$(echo "$tmpresult3" | grep -woP '"message"\s{0,}:\s{0,}"\K[^"]+')
+    local result=$(echo "$tmpresult3" | $grep -woP '"resultCode"\s{0,}:\s{0,}"\K[^"]+')
+    local reason=$(echo "$tmpresult3" | $grep -woP '"message"\s{0,}:\s{0,}"\K[^"]+')
     case "$result" in
         "KO") echo -n -e "\r SonyLiv:\t\t\t\t${Font_Red}No (${reason})${Font_Suffix}\n" ;;
         "OK") echo -n -e "\r SonyLiv:\t\t\t\t${Font_Green}Yes (Region: ${region})${Font_Suffix}\n" ;;
@@ -4713,10 +4716,10 @@ function MediaUnlockTest_JioCinema() {
         return
     fi
 
-    local isBlocked1=$(echo "$tmpresult" | grep -i 'Access Denied')
-    local isOK1=$(echo "$tmpresult" | grep -i 'Success')
-    local isBlocked2=$(echo "$tmpresult2" | grep -i 'is unavailable at your')
-    local isOK2=$(echo "$tmpresult2" | grep -i 'Ok')
+    local isBlocked1=$(echo "$tmpresult" | $grep -i 'Access Denied')
+    local isOK1=$(echo "$tmpresult" | $grep -i 'Success')
+    local isBlocked2=$(echo "$tmpresult2" | $grep -i 'is unavailable at your')
+    local isOK2=$(echo "$tmpresult2" | $grep -i 'Ok')
 
     if [ -n "$isBlocked1" ] || [ -n "$isBlocked2" ]; then
         echo -n -e "\r Jio Cinema:\t\t\t\t${Font_Red}No${Font_Suffix}\n"
@@ -4737,14 +4740,14 @@ function MediaUnlockTest_MXPlayer() {
     fi
 
     local tmpresult=$(curl ${CURL_DEFAULT_OPTS} -sLi 'https://www.mxplayer.in/' -w "_TAG_%{http_code}_TAG_" --user-agent "${UA_BROWSER}")
-    local httpCode=$(echo "$tmpresult" | grep '_TAG_' | awk -F'_TAG_' '{print $2}')
+    local httpCode=$(echo "$tmpresult" | $grep '_TAG_' | awk -F'_TAG_' '{print $2}')
     if [ "$httpCode" == '000' ]; then
         echo -n -e "\r MX Player:\t\t\t\t${Font_Red}Failed (Network Connection)${Font_Suffix}\n"
         return
     fi
 
-    local isOK=$(echo "$tmpresult" | grep 'set-cookie')
-    local isBlocked=$(echo "$tmpresult" | grep -iE '403 ERROR|not available in your')
+    local isOK=$(echo "$tmpresult" | $grep 'set-cookie')
+    local isBlocked=$(echo "$tmpresult" | $grep -iE '403 ERROR|not available in your')
 
     if [ -n "$isBlocked" ]; then
         echo -n -e "\r MX Player:\t\t\t\t${Font_Red}No${Font_Suffix}\n"
@@ -4760,13 +4763,13 @@ function MediaUnlockTest_MXPlayer() {
 
 function MediaUnlockTest_Zee5() {
     local tmpresult=$(curl ${CURL_DEFAULT_OPTS} -sLi 'https://www.zee5.com/' -w "_TAG_%{http_code}_TAG_" -H 'Upgrade-Insecure-Requests: 1' --user-agent "${UA_BROWSER}")
-    local httpCode=$(echo "$tmpresult" | grep '_TAG_' | awk -F'_TAG_' '{print $2}')
+    local httpCode=$(echo "$tmpresult" | $grep '_TAG_' | awk -F'_TAG_' '{print $2}')
     if [ "$httpCode" == '000' ]; then
         echo -n -e "\r Zee5:\t\t\t\t\t${Font_Red}Failed (Network Connection)${Font_Suffix}\n"
         return
     fi
 
-    local region=$(echo "$tmpresult" | grep -woP 'country=\K[A-Z]{2}' | head -n 1)
+    local region=$(echo "$tmpresult" | $grep -woP 'country=\K[A-Z]{2}' | head -n 1)
     if [ -n "$region" ]; then
         echo -n -e "\r Zee5:\t\t\t\t\t${Font_Green}Yes (Region: ${region})${Font_Suffix}\n"
         return
@@ -4787,7 +4790,7 @@ function WebTest_EroGameSpace() {
         return
     fi
 
-    local result=$(echo "$tmpresult" | grep -i '18歳')
+    local result=$(echo "$tmpresult" | $grep -i '18歳')
     if [ -n "$result" ]; then
         echo -n -e "\r EroGameSpace:\t\t\t\t${Font_Green}Yes${Font_Suffix}\n"
         return
@@ -4808,7 +4811,7 @@ function MediaUnlockTest_DAnimeStore() {
         return
     fi
 
-    local isBlocked=$(echo "$tmpresult" | grep '海外')
+    local isBlocked=$(echo "$tmpresult" | $grep '海外')
     if [ -n "$isBlocked" ];then
         echo -n -e "\r D Anime Store:\t\t\t\t${Font_Red}No${Font_Suffix}\n"
         return
@@ -4830,13 +4833,13 @@ function MediaUnlockTest_RakutenTVJP() {
         return
     fi
 
-    local isBlocked=$(echo "$tmpresult" | grep -i 'IS_FOREIGN')
+    local isBlocked=$(echo "$tmpresult" | $grep -i 'IS_FOREIGN')
     if [ -n "$isBlocked" ];then
         echo -n -e "\r Rakuten TV JP:\t\t\t\t${Font_Red}No${Font_Suffix}\n"
         return
     fi
 
-    local isOK=$(echo "$tmpresult" | grep -i 'in_vod')
+    local isOK=$(echo "$tmpresult" | $grep -i 'in_vod')
 
     if [ -z "$isBlocked" ] && [ -z "$isOK" ]; then
         echo -n -e "\r Rakuten TV JP:\t\t\t\t${Font_Red}Failed (Error: PAGE ERROR)${Font_Suffix}\n"
@@ -4849,7 +4852,7 @@ function MediaUnlockTest_RakutenTVJP() {
         return
     fi
 
-    local isDomestic=$(echo "$tmpresult1" | grep -woP '"is_domestic"\s{0,}:\s{0,}\K(false|true)')
+    local isDomestic=$(echo "$tmpresult1" | $grep -woP '"is_domestic"\s{0,}:\s{0,}\K(false|true)')
 
     case "$isDomestic" in
         'false') echo -n -e "\r Rakuten TV JP:\t\t\t\t${Font_Yellow}No (NBA Unavailable)${Font_Suffix}\n" ;;
@@ -4869,7 +4872,7 @@ function MediaUnlockTest_AMCPlus() {
     fi
 
     local urlEffective=$(echo "$tmpresult" | awk -F'_TAG_' '{print $2}')
-    local isBlocked=$(echo "$urlEffective" | grep -i 'geographic-restriction')
+    local isBlocked=$(echo "$urlEffective" | $grep -i 'geographic-restriction')
     local region=$(echo "$urlEffective" | awk -F'/' '{print $NF}' | tr A-Z a-z | sed 's/\b[a-z]/\U&/g')
 
     if [ -n "$isBlocked" ]; then
@@ -4893,7 +4896,7 @@ function MediaUnlockTest_AMCPlus() {
 
 function echo_result() {
     for ((i=0;i<${#array[@]};i++)); do
-        echo "$result" | grep "${array[i]}"
+        echo "$result" | $grep "${array[i]}"
         delay 0.03
     done
 }
@@ -5073,13 +5076,13 @@ function EU_UnlockTest() {
     )
     wait
     show_region ES
-    echo "$result" | grep "Movistar+:"
+    echo "$result" | $grep "Movistar+:"
     show_region IT
-    echo "$result" | grep "Rai Play:"
+    echo "$result" | $grep "Rai Play:"
     show_region CH
-    echo "$result" | grep "SKY CH:"
+    echo "$result" | $grep "SKY CH:"
     show_region RU
-    echo "$result" | grep "Amediateka:"
+    echo "$result" | $grep "Amediateka:"
     echo "======================================="
 }
 

--- a/check.sh
+++ b/check.sh
@@ -227,6 +227,7 @@ check_net_connctivity() {
 check_os_type() {
     OS_TYPE=''
     grep='grep'
+    md5sum='md5sum'
     local ifLinux=$(uname -a | grep -i 'linux')
     local ifFreeBSD=$(uname -a | grep -i 'freebsd')
     local ifTermux=$(echo "$PWD" | grep -i 'termux')
@@ -251,6 +252,7 @@ check_os_type() {
         OS_TYPE='macos'
         OS_MACOS=1
         grep='ggrep'
+        md5sum='md5 -r'
         return
     fi
     if [ -n "$ifMinGW" ]; then
@@ -340,17 +342,6 @@ check_dependencies() {
     if ! command_exists openssl; then
         echo -e "${Font_Red}command 'openssl' is missing, please install it first.${Font_Suffix}"
         exit 1
-    fi
-
-    if [ "$OS_MACOS" == 1 ]; then
-        if ! command_exists md5sum; then
-            echo -e "${Font_Red}command 'md5sum' is missing, please install it first.${Font_Suffix}"
-            exit 1
-        fi
-        if ! command_exists sha256sum; then
-            echo -e "${Font_Red}command 'sha256sum' is missing, please install it first.${Font_Suffix}"
-            exit 1
-        fi
     fi
 
     if [ "$OS_NAME" == 'debian' ] || [ "$OS_NAME" == 'ubuntu' ]; then
@@ -589,7 +580,7 @@ function MediaUnlockTest_BilibiliChinaMainland() {
         return
     fi
 
-    local randsession=$(gen_uuid | md5sum | head -c 32)
+    local randsession=$(gen_uuid | $md5sum | head -c 32)
     # 尝试获取成功的结果
     local tmpresult=$(curl ${CURL_DEFAULT_OPTS} -fsL "https://api.bilibili.com/pgc/player/web/playurl?avid=82846771&qn=0&type=&otype=json&ep_id=307247&fourk=1&fnver=0&fnval=16&session=${randsession}&module=bangumi" --user-agent "${UA_BROWSER}")
     if [ -z "$tmpresult" ]; then
@@ -612,7 +603,7 @@ function MediaUnlockTest_BilibiliHKMCTW() {
         return
     fi
 
-    local randsession=$(gen_uuid | md5sum | head -c 32)
+    local randsession=$(gen_uuid | $md5sum | head -c 32)
     # 尝试获取成功的结果
     local tmpresult=$(curl ${CURL_DEFAULT_OPTS} -fsL "https://api.bilibili.com/pgc/player/web/playurl?avid=18281381&cid=29892777&qn=0&type=&otype=json&ep_id=183799&fourk=1&fnver=0&fnval=16&session=${randsession}&module=bangumi" --user-agent "${UA_BROWSER}")
     if [ -z "$tmpresult" ]; then
@@ -635,7 +626,7 @@ function MediaUnlockTest_BilibiliTW() {
         return
     fi
 
-    local randsession=$(gen_uuid | md5sum | head -c 32)
+    local randsession=$(gen_uuid | $md5sum | head -c 32)
     # 尝试获取成功的结果
     local tmpresult=$(curl ${CURL_DEFAULT_OPTS} -fsL "https://api.bilibili.com/pgc/player/web/playurl?avid=50762638&cid=100279344&qn=0&type=&otype=json&ep_id=268176&fourk=1&fnver=0&fnval=16&session=${randsession}&module=bangumi" --user-agent "${UA_BROWSER}")
     if [ -z "$tmpresult" ]; then
@@ -1075,7 +1066,7 @@ function MediaUnlockTest_wowow() {
 
     local metaId=$(echo "$tmpresult3" | $grep -woP '"https://wod.wowow.co.jp/watch/\K\d{0,}[^"]+')
     # Fake Vistor UID
-    local vUid=$(echo -n "$timestamp" | md5sum | cut -f1 -d' ')
+    local vUid=$(echo -n "$timestamp" | $md5sum | cut -f1 -d' ')
     # 最终测试
     local tmpresult4=$(curl ${CURL_DEFAULT_OPTS} -s 'https://mapi.wowow.co.jp/api/v1/playback/auth' -H 'accept: application/json, text/plain, */*' -H 'content-type: application/json;charset=UTF-8' -H 'origin: https://wod.wowow.co.jp' -H 'referer: https://wod.wowow.co.jp/' -H 'accept-language: en-US,en;q=0.9' -H "sec-ch-ua: ${UA_SEC_CH_UA}" -H 'sec-ch-ua-mobile: ?0' -H 'sec-ch-ua-platform: "Windows"' -H 'sec-fetch-dest: empty' -H 'sec-fetch-mode: cors' -H 'sec-fetch-site: same-site' -H 'x-requested-with: XMLHttpRequest' --data-raw "{\"meta_id\":${metaId},\"vuid\":\"${vUid}\",\"device_code\":1,\"app_id\":1,\"ua\":\"${UA_BROWSER}\"}" --user-agent "${UA_BROWSER}")
     if [ -z "$tmpresult4" ]; then
@@ -2866,7 +2857,7 @@ function MediaUnlockTest_DiscoveryPlus() {
         return
     fi
 
-    local fakeDeviceId=$(gen_uuid | md5sum | cut -f1 -d' ')
+    local fakeDeviceId=$(gen_uuid | $md5sum | cut -f1 -d' ')
 
     local tmpresult1=$(curl ${CURL_DEFAULT_OPTS} -s "${baseApiUrl}/token?deviceId=${fakeDeviceId}&realm=${realm}&shortlived=true" -H 'accept: */*' -H 'accept-language: en-US,en;q=0.9' -H 'origin: https://www.discoveryplus.com' -H 'referer: https://www.discoveryplus.com/' -H "sec-ch-ua: ${UA_SEC_CH_UA}" -H 'sec-ch-ua-mobile: ?0' -H 'sec-ch-ua-platform: "Windows"' -H 'sec-fetch-dest: empty' -H 'sec-fetch-mode: cors' -H 'sec-fetch-site: same-site' -H "x-device-info: dplus_us/2.46.0 (desktop/desktop; Windows/NT 10.0; ${fakeDeviceId})" -H 'x-disco-client: WEB:UNKNOWN:dplus_us:2.46.0' -H "x-disco-params: realm=${realm},bid=dplus,hn=www.discoveryplus.com,hth=,features=ar" --user-agent "${UA_BROWSER}")
     if [ -z "$tmpresult1" ]; then
@@ -4400,8 +4391,8 @@ function MediaUnlockTest_AISPlay() {
 
     local userId='09e8b25510'
     local userPasswd='e49e9f9e7f'
-    local fakeApiKey=$(gen_uuid | md5sum | cut -f1 -d' ')
-    local fakeUdid=$(gen_uuid | md5sum | cut -f1 -d' ')
+    local fakeApiKey=$(gen_uuid | $md5sum | cut -f1 -d' ')
+    local fakeUdid=$(gen_uuid | $md5sum | cut -f1 -d' ')
     local timestamp=$(date +%s)
     local tmpresult=$(curl ${CURL_DEFAULT_OPTS} -sL "https://web-tls.ais-vidnt.com/device/login/?d=gstweb&gst=1&user=${userId}&pass=${userPasswd}" -H 'accept-language: th' -H 'api-version: 2.8.2' -H "api_key: ${fakeApiKey}" -H 'content-type: multipart/form-data; boundary=----WebKitFormBoundaryBj2RhUIW7BtRvfK0' -H 'device-info: com.vimmi.ais.portal, Windows + Chrome, AppVersion: 4.9.97, 10, language: tha' -H 'origin: https://aisplay.ais.co.th' -H "privateid: ${userId}" -H 'referer: https://aisplay.ais.co.th/' -H "sec-ch-ua: ${UA_SEC_CH_UA}" -H 'sec-ch-ua-mobile: ?0' -H 'sec-ch-ua-platform: "Windows"' -H 'sec-fetch-dest: empty' -H 'sec-fetch-mode: cors' -H 'sec-fetch-site: cross-site' -H "time: ${timestamp}" -H "udid: ${fakeUdid}" --data-raw $'------WebKitFormBoundaryBj2RhUIW7BtRvfK0--\r\n' --user-agent "${UA_BROWSER}")
     if [ -z "$tmpresult" ]; then


### PR DESCRIPTION
Use ggrep as grep for BSD systems
> This should resolve "command 'grep' function is incomplete, please install the full version first." as BSD systems use ggrep for GNU grep

Use md5 -r as md5sum for macOS systems
> This should resolve conflicts while installing "md5sha1sum" and "coreutils" together via brew, as they both providing "md5sum" binary, none of them are required now