### PR TITLE
Update Bing

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -4560,6 +4560,13 @@ function RegionTest_Bing() {
         return
     fi
 
+    local isRisky=$(echo "$tmpresult" | grep 'sj_cook.set("SRCHHPGUSR","HV"')
+
+    if [ -n "$isRisky" ]; then
+        echo -n -e "\r Bing Region:\t\t\t\t${Font_Yellow}${region} (Risky)${Font_Suffix}\n"
+        return
+    fi
+
     echo -n -e "\r Bing Region:\t\t\t\t${Font_Green}${region}${Font_Suffix}\n"
 }
 


### PR DESCRIPTION
Bing 存在 IP/ASN 拉黑机制，具体表现为：
搜索冷门关键词无结果，即使是热门关键词也是只有一些特定结果，应该与反爬虫相关。
当请求 ```https://www.bing.com/search?q=curl``` 时，会跳转至 ```https://www.bing.com/search?q=curl&rdr=1&rdrig=B01C8926D1114E1B95F89FBE5A63EB25```

![QQ20240725-162031](https://github.com/user-attachments/assets/3145a851-b68d-4e30-b14d-2eee4fb63dfb)
![QQ20240725-162100](https://github.com/user-attachments/assets/43d263ec-96ce-4363-9f5b-3025f4c8a6fd)

除了几个大厂的 ASN 以外，热门落地线路 AS38136 Akari Networks 的 ASN 也在 Bing 黑名单（部分下游商家可能对 Bing 做了 DNS 解锁所以没有体现出来）。

通过分析 JS，分析是如何跳转的：
JS 文件：```https://www.bing.com/rp/LjE9tm9ZRDtSQRcB5OmOGTN7JMQ.br.js```
```
h = sj_cook.get("SRCHHPGUSR", "HV"),
h && h.length > 0 && location.href.indexOf("&rdr=1") === -1 && location.href.indexOf("?") > 0 ? (c = location.href + "&rdr=1" + (_G && _G.IG ? "&rdrig=" + _G.IG : "")
```
![QQ20240725-161744](https://github.com/user-attachments/assets/2c8cede6-6399-4e03-8d6a-611e7583c5e9)
当 Cookie SRCHHPGUSR 的值中包含 HV，则进行跳转。

进一步分析 HV 是如何来的：
使用 Akari Networks 新加坡线路，关闭 DNS 解锁，查看 ```https://www.bing.com/search?q=curl``` 的响应，并与其他正常的节点响应进行比对，发现命中反爬后，页面会有代码添加这个 HV 到 Cookie：
```
sj_cook.set("SRCHHPGUSR","HV",i,!1,"/")
```
由于能力有限，暂时只能做到匹配字符串前面部分 ```sj_cook.set("SRCHHPGUSR","HV"```，后面的因为是变量，可能需要正则表达式来匹配。