### PR TITLE
Fixed the example commands in README_EN.md

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -67,22 +67,22 @@ This script was modified based on [CoiaPrant/MediaUnlock_Test](https://github.co
 
 **General Use**
 ````bash
-bash <(curl -L -s https://git.io/JRw8R) -E
+bash <(curl -L -s https://git.io/JRw8R) -E en
 ````
 
 **Test IPv4 Result Only**
 ````bash
-bash <(curl -L -s https://git.io/JRw8R) -E -M 4
+bash <(curl -L -s https://git.io/JRw8R) -E en -M 4
 ````
 
 **Test IPv6 Result Only**
 ````bash
-bash <(curl -L -s https://git.io/JRw8R) -E -M 6
+bash <(curl -L -s https://git.io/JRw8R) -E en -M 6
 ````
 
 **Specify a Certain Interface to be Tested**
 ````bash
-bash <(curl -L -s https://git.io/JRw8R) -E -I eth0
+bash <(curl -L -s https://git.io/JRw8R) -E en -I eth0
 ````
 
 **Or run in docker**

--- a/check.sh
+++ b/check.sh
@@ -5865,7 +5865,7 @@ function showGoodbye() {
         echo -e "${Font_Yellow}Number of Script Runs for Today: ${TODAY_RUN_TIMES}; Total Number of Script Runs: ${TOTAL_RUN_TIMES}${Font_Suffix}"
         echo -e ''
         echo -e "========================================================="
-        echo -e "${Font_Red}If you found this script helpful, you can but me a coffee${Font_Suffix}"
+        echo -e "${Font_Red}If you found this script helpful, you can buy me a coffee${Font_Suffix}"
         echo -e ''
         echo -e "LTC: LQD4S6Y5bu3bHX6hx8ASsGHVfaqFGFNTbx"
         echo -e "========================================================="


### PR DESCRIPTION
The original example commands in README_EN.md fallbacks to Chinese, never setting the language to English, now it does